### PR TITLE
Add unsound2 and fix for Send + 'static as found by SSLab-gatech

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,10 @@
+## Author
+
+* William Brown (Firstyear): william@blackhats.net.au
+
+## Contributors
+
+* Jake (slipperyBishop)
+* Youngsuk Kim (@JOE1994)
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "MPL-2.0"
 [features]
 simd_support = ["packed_simd"]
 skinny = []
+unsoundness = []
 
 [dependencies]
 crossbeam-epoch = "0.8"
@@ -34,3 +35,10 @@ time = "0.2"
 name = "unsound"
 path = "src/unsound.rs"
 
+[[bin]]
+name = "unsound2"
+path = "src/unsound2.rs"
+
+[[bin]]
+name = "unsound3"
+path = "src/unsound3.rs"

--- a/src/bptree/cursor.rs
+++ b/src/bptree/cursor.rs
@@ -99,6 +99,7 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
 
     fn get_txid(&self) -> u64;
 
+    #[cfg(test)]
     fn get_tree_density(&self) -> (usize, usize) {
         // Walk the tree and calculate the packing effeciency.
         let rref = self.get_root_ref();
@@ -474,6 +475,7 @@ impl<K: Clone + Ord + Debug, V: Clone> CursorWrite<K, V> {
         self.get_root_ref().get_txid()
     }
 
+    #[cfg(test)]
     pub(crate) fn tree_density(&self) -> (usize, usize) {
         self.get_root_ref().tree_density()
     }
@@ -2188,7 +2190,7 @@ mod tests {
         let mut ins: Vec<usize> = (1..(L_CAPACITY << 4)).collect();
         ins.shuffle(&mut rng);
 
-        let mut sblock = SuperBlock::default();
+        let sblock = SuperBlock::default();
         let mut wcurs = CursorWrite::new(&sblock);
 
         for v in ins.into_iter() {

--- a/src/bptree/node.rs
+++ b/src/bptree/node.rs
@@ -252,6 +252,7 @@ impl<K: Clone + Ord + Debug, V: Clone> Node<K, V> {
     }
 
     #[inline(always)]
+    #[cfg(test)]
     pub(crate) fn get_txid(&self) -> u64 {
         self.meta.get_txid()
     }
@@ -262,10 +263,12 @@ impl<K: Clone + Ord + Debug, V: Clone> Node<K, V> {
     }
 
     #[inline(always)]
+    #[cfg(test)]
     pub(crate) fn is_branch(&self) -> bool {
         self.meta.is_branch()
     }
 
+    #[cfg(test)]
     pub(crate) fn tree_density(&self) -> (usize, usize) {
         match self.meta.0 & FLAG_MASK {
             FLAG_LEAF => {
@@ -486,6 +489,7 @@ impl Meta {
 
 impl<K: Ord + Clone + Debug, V: Clone> Leaf<K, V> {
     #[inline(always)]
+    #[cfg(test)]
     fn set_count(&mut self, c: usize) {
         debug_assert_leaf!(self);
         self.meta.set_count(c)
@@ -780,7 +784,8 @@ impl<K: Ord + Clone + Debug, V: Clone> Leaf<K, V> {
 
     fn free(node: *mut Self) {
         unsafe {
-            let _x: Box<CachePadded<Leaf<K, V>>> = Box::from_raw(node as *mut CachePadded<Leaf<K, V>>);
+            let _x: Box<CachePadded<Leaf<K, V>>> =
+                Box::from_raw(node as *mut CachePadded<Leaf<K, V>>);
         }
     }
 }
@@ -821,6 +826,7 @@ impl<K: Ord + Clone + Debug, V: Clone> Drop for Leaf<K, V> {
 
 impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
     #[inline(always)]
+    #[cfg(test)]
     fn set_count(&mut self, c: usize) {
         debug_assert_branch!(self);
         self.meta.set_count(c)
@@ -1793,7 +1799,8 @@ impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
 
     fn free(node: *mut Self) {
         unsafe {
-            let mut _x: Box<CachePadded<Branch<K, V>>> = Box::from_raw(node as *mut CachePadded<Branch<K, V>>);
+            let mut _x: Box<CachePadded<Branch<K, V>>> =
+                Box::from_raw(node as *mut CachePadded<Branch<K, V>>);
         }
     }
 }

--- a/src/hashmap/cursor.rs
+++ b/src/hashmap/cursor.rs
@@ -100,6 +100,7 @@ pub(crate) trait CursorReadOps<K: Clone + Hash + Eq + Debug, V: Clone> {
 
     fn get_txid(&self) -> u64;
 
+    #[cfg(test)]
     fn get_tree_density(&self) -> (usize, usize, usize) {
         // Walk the tree and calculate the packing effeciency.
         let rref = self.get_root_ref();
@@ -421,6 +422,7 @@ impl<K: Clone + Hash + Eq + Debug, V: Clone> CursorWrite<K, V> {
         self.get_root_ref().get_txid()
     }
 
+    #[cfg(test)]
     pub(crate) fn tree_density(&self) -> (usize, usize, usize) {
         self.get_root_ref().tree_density()
     }
@@ -1014,7 +1016,7 @@ where
             path_get_slot_mut_ref(anode, h).map(|v| v as *mut [Datum<K, V>]);
 
         // I solemly swear I am up to no good.
-        r.map(|v| unsafe { &mut *v as &mut [Datum<K, V>] })
+        r.map(|v| &mut *v as &mut [Datum<K, V>])
     }
 }
 
@@ -1987,7 +1989,7 @@ mod tests {
         let mut ins: Vec<usize> = (1..(H_CAPACITY << 4)).collect();
         ins.shuffle(&mut rng);
 
-        let mut sblock = SuperBlock::default();
+        let sblock = SuperBlock::default();
         let mut wcurs = CursorWrite::new(&sblock);
 
         for v in ins.into_iter() {

--- a/src/hashmap/macros.rs
+++ b/src/hashmap/macros.rs
@@ -12,20 +12,29 @@ macro_rules! debug_assert_branch {
 
 macro_rules! self_meta {
     ($x:expr) => {{
-        unsafe { &mut *($x as *mut Meta) }
+        #[allow(unused_unsafe)]
+        unsafe {
+            &mut *($x as *mut Meta)
+        }
     }};
 }
 
 macro_rules! branch_ref {
     ($x:expr, $k:ty, $v:ty) => {{
-        debug_assert!(unsafe { (*$x).meta.is_branch() });
-        unsafe { &mut *($x as *mut Branch<$k, $v>) }
+        #[allow(unused_unsafe)]
+        unsafe {
+            debug_assert!((*$x).meta.is_branch());
+            &mut *($x as *mut Branch<$k, $v>)
+        }
     }};
 }
 
 macro_rules! leaf_ref {
     ($x:expr, $k:ty, $v:ty) => {{
-        debug_assert!(unsafe { (*$x).meta.is_leaf() });
-        unsafe { &mut *($x as *mut Leaf<$k, $v>) }
+        #[allow(unused_unsafe)]
+        unsafe {
+            debug_assert!((*$x).meta.is_leaf());
+            &mut *($x as *mut Leaf<$k, $v>)
+        }
     }};
 }

--- a/src/hashmap/node.rs
+++ b/src/hashmap/node.rs
@@ -40,15 +40,16 @@ pub(crate) const HBV_CAPACITY: usize = H_CAPACITY + 1;
 const DEFAULT_BUCKET_ALLOC: usize = 1;
 
 #[cfg(not(feature = "simd_support"))]
+#[allow(non_camel_case_types)]
 pub struct u64x8 {
-    data: [u64; 8],
+    _data: [u64; 8],
 }
 
 #[cfg(not(feature = "simd_support"))]
 impl u64x8 {
     fn new(a: u64, b: u64, c: u64, d: u64, e: u64, f: u64, g: u64, h: u64) -> Self {
         Self {
-            data: [a, b, c, d, e, f, g, h],
+            _data: [a, b, c, d, e, f, g, h],
         }
     }
 }
@@ -284,6 +285,7 @@ impl<K: Clone + Eq + Hash + Debug, V: Clone> Node<K, V> {
     }
 
     #[inline(always)]
+    #[cfg(test)]
     pub(crate) fn get_txid(&self) -> u64 {
         self.meta.get_txid()
     }
@@ -294,10 +296,12 @@ impl<K: Clone + Eq + Hash + Debug, V: Clone> Node<K, V> {
     }
 
     #[inline(always)]
+    #[cfg(test)]
     pub(crate) fn is_branch(&self) -> bool {
         self.meta.is_branch()
     }
 
+    #[cfg(test)]
     pub(crate) fn tree_density(&self) -> (usize, usize, usize) {
         match self.meta.0 & FLAG_MASK {
             FLAG_HASH_LEAF => {
@@ -520,6 +524,7 @@ impl Meta {
 
 impl<K: Hash + Eq + Clone + Debug, V: Clone> Leaf<K, V> {
     #[inline(always)]
+    #[cfg(test)]
     fn set_slots(&mut self, c: usize) {
         debug_assert_leaf!(self);
         self.meta.set_slots(c)
@@ -595,7 +600,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> Leaf<K, V> {
     {
         debug_assert_leaf!(self);
         leaf_simd_get_slot(self, h)
-            .map(|slot_idx| unsafe { (*self.values[slot_idx].as_mut_ptr()).as_mut_slice() })
+            .map(|slot_idx| (*self.values[slot_idx].as_mut_ptr()).as_mut_slice())
     }
 
     #[inline(always)]
@@ -913,7 +918,8 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> Leaf<K, V> {
 
     fn free(node: *mut Self) {
         unsafe {
-            let _x: Box<CachePadded<Leaf<K, V>>> = Box::from_raw(node as *mut CachePadded<Leaf<K, V>>);
+            let _x: Box<CachePadded<Leaf<K, V>>> =
+                Box::from_raw(node as *mut CachePadded<Leaf<K, V>>);
         }
     }
 }
@@ -958,6 +964,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> Drop for Leaf<K, V> {
 
 impl<K: Hash + Eq + Clone + Debug, V: Clone> Branch<K, V> {
     #[inline(always)]
+    #[cfg(test)]
     fn set_slots(&mut self, c: usize) {
         debug_assert_branch!(self);
         self.meta.set_slots(c)
@@ -1961,7 +1968,8 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> Branch<K, V> {
     #[allow(clippy::cast_ptr_alignment)]
     fn free(node: *mut Self) {
         unsafe {
-            let mut _x: Box<CachePadded<Branch<K, V>>> = Box::from_raw(node as *mut CachePadded<Branch<K, V>>);
+            let mut _x: Box<CachePadded<Branch<K, V>>> =
+                Box::from_raw(node as *mut CachePadded<Branch<K, V>>);
         }
     }
 }

--- a/src/unsound2.rs
+++ b/src/unsound2.rs
@@ -1,0 +1,44 @@
+#![forbid(unsafe_code)]
+extern crate concread;
+
+#[cfg(not(feature = "unsoundness"))]
+fn main() {
+    eprintln!("Recompile with --features unsoundness");
+}
+
+#[cfg(feature = "unsoundness")]
+fn main() {
+    use concread::arcache::ARCache;
+    use std::rc::Rc;
+    use std::sync::Arc;
+
+    let non_sync_item = Rc::new(0); // neither `Send` nor `Sync`
+    assert_eq!(Rc::strong_count(&non_sync_item), 1);
+
+    let cache = ARCache::<i32, Rc<u64>>::new_size(5, 5);
+    let mut writer = cache.write();
+    writer.insert(0, non_sync_item);
+    writer.commit();
+
+    let arc_parent = Arc::new(cache);
+
+    let mut handles = vec![];
+    for _ in 0..5 {
+        let arc_child = arc_parent.clone();
+        let child_handle = std::thread::spawn(move || {
+            let reader = arc_child.read(); // new Reader of ARCache
+            let smuggled_rc = reader.get(&0).unwrap();
+
+            for _ in 0..1000 {
+                let _dummy_clone = Rc::clone(&smuggled_rc); // Increment `strong_count` of `Rc`
+                                                            // When `_dummy_clone` is dropped, `strong_count` is decremented.
+            }
+        });
+        handles.push(child_handle);
+    }
+    for handle in handles {
+        handle.join().expect("failed to join child thread");
+    }
+
+    assert_eq!(Rc::strong_count(arc_parent.read().get(&0).unwrap()), 1);
+}


### PR DESCRIPTION
Due to a missing `Send + 'static` bound, The map types were able to have incorrect data inserted - this previously affected EBRCell. 