### PR TITLE
HashMap Cursor: Modified search to work iteratively instead of recursively

### DIFF
--- a/src/hashmap/node.rs
+++ b/src/hashmap/node.rs
@@ -121,7 +121,7 @@ where
     pub key: [u64; H_CAPACITY],
     #[cfg(all(test, not(miri)))]
     poison: u64,
-    nodes: [*mut Node<K, V>; HBV_CAPACITY],
+    pub(crate) nodes: [*mut Node<K, V>; HBV_CAPACITY],
     #[cfg(all(test, not(miri)))]
     pub nid: usize,
 }


### PR DESCRIPTION
A simple modification of CursorReadOps::search that makes it work iteratively.
- benchmarks indicate a slight improvement in performance
- ! for reasons unknown to me, rustc wouldn't let me use is_branch saying it doesn't exist, although it's clearly there and pub(crate); corrupted flags are therefore not checked
- ! I needed to make Branch::nodes pub(crate), didn't seem like it could lead to any problems
- did not delete Node (and Leaf, Branch) get_ref yet, they are now unused