### PR TITLE
Refactor Branch and Leaf into unions

### DIFF
--- a/src/internals/hashmap/macros.rs
+++ b/src/internals/hashmap/macros.rs
@@ -8,13 +8,13 @@ macro_rules! hash_key {
 
 macro_rules! debug_assert_leaf {
     ($x:expr) => {{
-        debug_assert!($x.meta.is_leaf());
+        debug_assert!(unsafe { $x.ctrl.a.0.is_leaf() });
     }};
 }
 
 macro_rules! debug_assert_branch {
     ($x:expr) => {{
-        debug_assert!($x.meta.is_branch());
+        debug_assert!(unsafe { $x.ctrl.a.0.is_branch() });
     }};
 }
 
@@ -31,7 +31,7 @@ macro_rules! branch_ref {
     ($x:expr, $k:ty, $v:ty) => {{
         #[allow(unused_unsafe)]
         unsafe {
-            debug_assert!((*$x).meta.is_branch());
+            debug_assert!(unsafe { (*$x).ctrl.a.0.is_branch() });
             &mut *($x as *mut Branch<$k, $v>)
         }
     }};
@@ -41,7 +41,7 @@ macro_rules! leaf_ref {
     ($x:expr, $k:ty, $v:ty) => {{
         #[allow(unused_unsafe)]
         unsafe {
-            debug_assert!((*$x).meta.is_leaf());
+            debug_assert!(unsafe { (*$x).ctrl.a.0.is_leaf() });
             &mut *($x as *mut Leaf<$k, $v>)
         }
     }};


### PR DESCRIPTION
Instead of having a Branch and a BranchSimd struct,
use Branch with a Ctrl union containing both the "normal"
branch and the SIMD one. Same thing with Leaf.