### PR TITLE
enable chonk nodes by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ arcache = ["maps", "lru"]
 skinny = []
 hashtrie_chonk = []
 
-default = ["asynch", "ahash", "ebr", "maps", "arcache"]
+default = ["asynch", "ahash", "ebr", "maps", "arcache", "hashtrie_chonk"]
 
 [dependencies]
 ahash = { version = "0.7", optional = true }
@@ -48,6 +48,7 @@ rand = "0.8"
 time = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
 uuid = "1.0"
+function_name = "0.3"
 
 [[bench]]
 name = "hashmap_benchmark"

--- a/benches/arccache.rs
+++ b/benches/arccache.rs
@@ -332,7 +332,8 @@ where
         let v = backing_set.get(&k).cloned().unwrap();
 
         // hit/miss process.
-        if !wr_txn.contains_key(&k) {
+        let cont = wr_txn.contains_key(&k);
+        if !cont {
             wr_txn.insert(k, v);
         }
     }
@@ -450,7 +451,8 @@ where
         let start = Instant::now();
         let mut wr_txn = arc.write();
         // hit/miss process.
-        if wr_txn.contains_key(&k) {
+        let cont = wr_txn.contains_key(&k);
+        if cont {
             hit_count += 1;
         } else {
             if let Some(delay) = backing_set_delay {

--- a/src/arcache/mod.rs
+++ b/src/arcache/mod.rs
@@ -1814,7 +1814,7 @@ impl<
     }
 
     /// Determine if this cache contains the following key.
-    pub fn contains_key<'b, Q: ?Sized>(&'a mut self, k: &'b Q) -> bool
+    pub fn contains_key<Q: ?Sized>(&mut self, k: &Q) -> bool
     where
         K: Borrow<Q>,
         Q: Hash + Eq + Ord,

--- a/src/internals/hashtrie/cursor.rs
+++ b/src/internals/hashtrie/cursor.rs
@@ -47,6 +47,7 @@ const SHIFT: u64 = 3;
 #[cfg(feature = "hashtrie_chonk")]
 pub(crate) const MAX_HEIGHT: u64 = 6;
 #[cfg(feature = "hashtrie_chonk")]
+#[cfg(test)]
 const ABS_MAX_HEIGHT: u64 = 16;
 #[cfg(feature = "hashtrie_chonk")]
 pub(crate) const HT_CAPACITY: usize = 16;


### PR DESCRIPTION
This yields a significant improvement to performance of the hashtrie and arcache as a result. 