### PR TITLE
Add ?Sized bounds for range methods

### DIFF
--- a/src/bptree/impl.rs
+++ b/src/bptree/impl.rs
@@ -195,7 +195,7 @@ impl<'a, K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send 
     pub fn range<'b, R, T>(&'b self, range: R) -> RangeIter<'b, K, V>
     where
         K: Borrow<T>,
-        T: Ord,
+        T: Ord + ?Sized,
         R: RangeBounds<T>,
     {
         self.inner.as_ref().range(range)
@@ -344,7 +344,7 @@ impl<'a, K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send 
     pub fn range<'b, R, T>(&'b self, range: R) -> RangeIter<'b, K, V>
     where
         K: Borrow<T>,
-        T: Ord,
+        T: Ord + ?Sized,
         R: RangeBounds<T>,
     {
         self.inner.as_ref().range(range)
@@ -435,7 +435,7 @@ impl<'a, K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send 
     pub fn range<'b, R, T>(&'b self, range: R) -> RangeIter<'b, K, V>
     where
         K: Borrow<T>,
-        T: Ord,
+        T: Ord + ?Sized,
         R: RangeBounds<T>,
     {
         match self.inner {

--- a/src/internals/bptree/cursor.rs
+++ b/src/internals/bptree/cursor.rs
@@ -253,7 +253,7 @@ pub(crate) trait CursorReadOps<K: Clone + Ord + Debug, V: Clone> {
     fn range<'a, R, T>(&'a self, range: R) -> RangeIter<'a, K, V>
     where
         K: Borrow<T>,
-        T: Ord,
+        T: Ord + ?Sized,
         R: RangeBounds<T>,
     {
         RangeIter::new(self.get_root(), range, self.len())

--- a/src/internals/bptree/iter.rs
+++ b/src/internals/bptree/iter.rs
@@ -25,7 +25,7 @@ where
 {
     pub(crate) fn new<T>(root: *mut Node<K, V>, bound: Bound<&T>) -> Self
     where
-        T: Ord,
+        T: Ord + ?Sized,
         K: Borrow<T>,
     {
         // We need to position the VecDeque here.
@@ -165,7 +165,7 @@ where
 {
     pub(crate) fn new<T>(root: *mut Node<K, V>, bound: Bound<&T>) -> Self
     where
-        T: Ord,
+        T: Ord + ?Sized,
         K: Borrow<T>,
     {
         // We need to position the VecDeque here.
@@ -443,7 +443,7 @@ where
 {
     pub(crate) fn new<R, T>(root: *mut Node<K, V>, range: R, length: usize) -> Self
     where
-        T: Ord,
+        T: Ord + ?Sized,
         K: Borrow<T>,
         R: RangeBounds<T>,
     {


### PR DESCRIPTION
I've noticed that `range` method doesn't provide `Q: ?Sized` bounds in contrast with [`BTreeMap::range`](https://doc.rust-lang.org/stable/std/collections/struct.BTreeMap.html#method.range) so i added missing type bound.

This bound could be useful for types like `T: RangeBounds<dyn Trait>`.
