### PR TITLE
Bump ahash and lru dependencies to their current stable versions

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -17,6 +17,6 @@ jobs:
         toolchain: stable
 
     - name: Cargo test
-      run: cargo test
+      run: cargo test --features tcache
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hashtrie_skinny = []
 default = ["asynch", "ahash", "ebr", "maps", "arcache"]
 
 [dependencies]
-ahash = { version = "0.7", optional = true }
+ahash = { version = "0.8", optional = true }
 crossbeam-utils = { version = "0.8.12", optional = true }
 crossbeam-epoch = { version = "0.9.11", optional = true }
 crossbeam-queue = { version = "0.3.6", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ahash = { version = "0.8", optional = true }
 crossbeam-utils = { version = "0.8.12", optional = true }
 crossbeam-epoch = { version = "0.9.11", optional = true }
 crossbeam-queue = { version = "0.3.6", optional = true }
-lru = { version = "0.7", optional = true }
+lru = { version = "0.12", optional = true }
 smallvec = { version = "1.4", optional = true }
 sptr = "0.3"
 tokio = { version = "1", features = ["sync"], optional = true }

--- a/src/threadcache/mod.rs
+++ b/src/threadcache/mod.rs
@@ -14,6 +14,7 @@
 //! the properties of this module.
 
 use std::collections::HashSet;
+use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
@@ -95,6 +96,8 @@ where
     /// cache instances will be returned that you can then distribute to the threads.
     pub fn new(threads: usize, capacity: usize) -> Vec<Self> {
         assert!(threads > 0);
+        let capacity = NonZeroUsize::new(capacity).unwrap();
+
         let (txs, rxs): (Vec<_>, Vec<_>) = (0..threads)
             .into_iter()
             .map(|_| channel::<Invalidate<K>>())


### PR DESCRIPTION
Closes #94 