### PR TITLE
RFC: Add optional Serde support for HashMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ crossbeam-utils = { version = "0.8.12", optional = true }
 crossbeam-epoch = { version = "0.9.11", optional = true }
 crossbeam-queue = { version = "0.3.6", optional = true }
 lru = { version = "0.12", optional = true }
+serde = { version = "1.0", optional = true }
 smallvec = { version = "1.4", optional = true }
 sptr = "0.3"
 tokio = { version = "1", features = ["sync"], optional = true }
@@ -49,6 +50,7 @@ time = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
 uuid = "1.0"
 function_name = "0.3"
+serde_json = "1.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 
 [[bench]]

--- a/benches/hashmap_benchmark.rs
+++ b/benches/hashmap_benchmark.rs
@@ -19,7 +19,7 @@ extern crate criterion;
 extern crate rand;
 
 use concread::hashmap::*;
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use rand::{thread_rng, Rng};
 
 // ranges of counts for different benchmarks (MINs are inclusive, MAXes exclusive):
@@ -190,8 +190,7 @@ fn remove_vec<'a, V: Clone + Sync + Send + 'static>(
 fn search_vec<V: Clone + Sync + Send + 'static>(map: &HashMap<u32, V>, list: &Vec<u32>) {
     let read_txn = map.read();
     for i in list.iter() {
-        // ! This could potentially get optimized into nothing !
-        read_txn.get(&i);
+        read_txn.get(black_box(i));
     }
 }
 
@@ -265,7 +264,7 @@ fn prepare_remove<V: Clone + Sync + Send + 'static>(value: V) -> (HashMap<u32, V
     for i in random_order(insert_count, insert_count).iter() {
         // We could count on the hash function alone to make the order random, but it seems
         // better to count on every possible implementation.
-        write_txn.insert(i.clone(), value.clone());
+        write_txn.insert(*i, value.clone());
     }
     write_txn.commit();
     (map, random_order(insert_count, remove_count))

--- a/src/bptree/asynch.rs
+++ b/src/bptree/asynch.rs
@@ -40,7 +40,6 @@ mod tests {
     use crate::internals::bptree::node::{assert_released, L_CAPACITY};
     // use rand::prelude::*;
     use rand::seq::SliceRandom;
-    use std::iter::FromIterator;
 
     #[tokio::test]
     async fn test_bptree2_map_basic_write() {
@@ -197,7 +196,7 @@ mod tests {
 
         let r3 = map.read().await;
         // println!("{:?}", r3.len());
-        assert!(r3.len() == 0);
+        assert!(r3.is_empty());
 
         std::mem::drop(r);
         std::mem::drop(r2);
@@ -261,9 +260,9 @@ mod tests {
         let rd = map.read().await;
 
         wr.insert(1, 1);
-        assert!(rd.get(&1) == None);
+        assert!(rd.get(&1).is_none());
         wr.commit().await;
-        assert!(rd.get(&1) == None);
+        assert!(rd.get(&1).is_none());
     }
 
     #[tokio::test]

--- a/src/bptree/impl.rs
+++ b/src/bptree/impl.rs
@@ -165,19 +165,19 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
 
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         self.inner.as_ref().search(k)
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         self.inner.as_ref().contains_key(k)
     }
@@ -317,19 +317,19 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         self.inner.as_ref().search(k)
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         self.inner.as_ref().contains_key(k)
     }
@@ -404,10 +404,10 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         match self.inner {
             SnapshotType::R(inner) => inner.search(k),
@@ -416,10 +416,10 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         match self.inner {
             SnapshotType::R(inner) => inner.contains_key(k),

--- a/src/bptree/mod.rs
+++ b/src/bptree/mod.rs
@@ -43,7 +43,6 @@ mod tests {
     use crate::internals::bptree::node::{assert_released, L_CAPACITY};
     // use rand::prelude::*;
     use rand::seq::SliceRandom;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_bptree2_map_basic_write() {
@@ -200,7 +199,7 @@ mod tests {
 
         let r3 = map.read();
         // println!("{:?}", r3.len());
-        assert!(r3.len() == 0);
+        assert!(r3.is_empty());
 
         std::mem::drop(r);
         std::mem::drop(r2);
@@ -264,9 +263,9 @@ mod tests {
         let rd = map.read();
 
         wr.insert(1, 1);
-        assert!(rd.get(&1) == None);
+        assert!(rd.get(&1).is_none());
         wr.commit();
-        assert!(rd.get(&1) == None);
+        assert!(rd.get(&1).is_none());
     }
 
     #[test]

--- a/src/cowcell/asynch.rs
+++ b/src/cowcell/asynch.rs
@@ -184,7 +184,7 @@ where
     fn deref(&self) -> &T {
         match &self.work {
             Some(v) => v,
-            None => &(*self.read),
+            None => &self.read,
         }
     }
 }
@@ -285,7 +285,7 @@ mod tests {
                 let mut cc_wrtxn = cc.write().await;
                 {
                     let mut_ptr = cc_wrtxn.get_mut();
-                    mut_ptr.data = mut_ptr.data + 1;
+                    mut_ptr.data += 1;
                 }
                 cc_wrtxn.commit().await;
             }

--- a/src/cowcell/mod.rs
+++ b/src/cowcell/mod.rs
@@ -216,7 +216,7 @@ where
     fn deref(&self) -> &T {
         match &self.work {
             Some(v) => v,
-            None => &(*self.read),
+            None => &self.read,
         }
     }
 }
@@ -335,7 +335,7 @@ mod tests {
                                 let mut_ptr = cc_wrtxn.get_mut();
                                 assert!(*mut_ptr >= last_value);
                                 last_value = *mut_ptr;
-                                *mut_ptr = *mut_ptr + 1;
+                                *mut_ptr += 1;
                             }
                             cc_wrtxn.commit();
                         }
@@ -378,7 +378,7 @@ mod tests {
                 let mut cc_wrtxn = cc.write();
                 {
                     let mut_ptr = cc_wrtxn.get_mut();
-                    mut_ptr.data = mut_ptr.data + 1;
+                    mut_ptr.data += 1;
                 }
                 cc_wrtxn.commit();
             }

--- a/src/ebrcell/mod.rs
+++ b/src/ebrcell/mod.rs
@@ -19,7 +19,6 @@ use crossbeam_epoch as epoch;
 use crossbeam_epoch::{Atomic, Guard, Owned};
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
-use std::marker::Send;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Mutex, MutexGuard};
@@ -359,7 +358,7 @@ mod tests {
                                 let mut_ptr = cc_wrtxn.get_mut();
                                 assert!(*mut_ptr >= last_value);
                                 last_value = *mut_ptr;
-                                *mut_ptr = *mut_ptr + 1;
+                                *mut_ptr += 1;
                             }
                             cc_wrtxn.commit();
                         }
@@ -401,7 +400,7 @@ mod tests {
                 let mut cc_wrtxn = cc.write();
                 {
                     let mut_ptr = cc_wrtxn.get_mut();
-                    mut_ptr.data = mut_ptr.data + 1;
+                    mut_ptr.data += 1;
                 }
                 cc_wrtxn.commit();
             }
@@ -494,7 +493,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write();
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit();
         }
@@ -505,7 +504,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write();
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit();
         }

--- a/src/hashmap/impl.rs
+++ b/src/hashmap/impl.rs
@@ -134,39 +134,39 @@ impl<
     > HashMapWriteTxn<'_, K, V>
 {
     /*
-    pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
+    pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().hash_key(k)
     }
     */
 
-    pub(crate) fn get_prehashed<Q: ?Sized>(&self, k: &Q, k_hash: u64) -> Option<&V>
+    pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().search(k_hash, k)
     }
 
     /// Retrieve a value from the map. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let k_hash = self.inner.as_ref().hash_key(k);
         self.get_prehashed(k, k_hash)
     }
 
     /// Assert if a key exists in the map.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }
@@ -241,30 +241,30 @@ impl<
         V: Clone + Sync + Send + 'static,
     > HashMapReadTxn<'_, K, V>
 {
-    pub(crate) fn get_prehashed<Q: ?Sized>(&self, k: &Q, k_hash: u64) -> Option<&V>
+    pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.search(k_hash, k)
     }
 
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let k_hash = self.inner.as_ref().hash_key(k);
         self.get_prehashed(k, k_hash)
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }
@@ -310,10 +310,10 @@ impl<
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self.inner {
             SnapshotType::R(inner) => {
@@ -328,10 +328,10 @@ impl<
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }

--- a/src/hashtrie/impl.rs
+++ b/src/hashtrie/impl.rs
@@ -132,39 +132,39 @@ impl<
     > HashTrieWriteTxn<'_, K, V>
 {
     /*
-    pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
+    pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().hash_key(k)
     }
     */
 
-    pub(crate) fn get_prehashed<Q: ?Sized>(&self, k: &Q, k_hash: u64) -> Option<&V>
+    pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().search(k_hash, k)
     }
 
     /// Retrieve a value from the map. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         let k_hash = self.inner.as_ref().hash_key(k);
         self.get_prehashed(k, k_hash)
     }
 
     /// Assert if a key exists in the map.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }
@@ -237,30 +237,30 @@ impl<
 impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
     HashTrieReadTxn<'_, K, V>
 {
-    pub(crate) fn get_prehashed<Q: ?Sized>(&self, k: &Q, k_hash: u64) -> Option<&V>
+    pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.search(k_hash, k)
     }
 
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq+ ?Sized,
     {
         let k_hash = self.inner.as_ref().hash_key(k);
         self.get_prehashed(k, k_hash)
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }
@@ -304,10 +304,10 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         match self.inner {
             SnapshotType::R(inner) => {
@@ -322,10 +322,10 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 
     /// Assert if a key exists in the tree.
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.get(k).is_some()
     }

--- a/src/hashtrie/mod.rs
+++ b/src/hashtrie/mod.rs
@@ -77,10 +77,10 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 
     #[cfg(feature = "arcache")]
-    pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
+    pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().hash_key(k)
     }
@@ -112,10 +112,10 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 
     #[cfg(feature = "arcache")]
-    pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
+    pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         self.inner.as_ref().hash_key(k)
     }

--- a/src/internals/bptree/iter.rs
+++ b/src/internals/bptree/iter.rs
@@ -359,7 +359,7 @@ where
 }
 
 impl<K: Clone + Ord + Debug, V: Clone> KeyIter<'_, '_, K, V> {
-    pub(crate) fn new<'n>(root: *mut Node<K, V>, length: usize) -> Self {
+    pub(crate) fn new(root: *mut Node<K, V>, length: usize) -> Self {
         KeyIter {
             iter: Iter::new(root, length),
         }
@@ -442,7 +442,7 @@ where
     K: Clone + Ord + Debug,
     V: Clone,
 {
-    pub(crate) fn new<'n, R, T>(root: *mut Node<K, V>, range: R, length: usize) -> Self
+    pub(crate) fn new<R, T>(root: *mut Node<K, V>, range: R, length: usize) -> Self
     where
         T: Ord + ?Sized,
         K: Borrow<T>,

--- a/src/internals/hashmap/simd.rs
+++ b/src/internals/hashmap/simd.rs
@@ -183,11 +183,11 @@ where
 */
 
 #[cfg(not(feature = "simd_support"))]
-pub(crate) fn leaf_simd_search<K, V, Q: ?Sized>(leaf: &Leaf<K, V>, h: u64, k: &Q) -> KeyLoc
+pub(crate) fn leaf_simd_search<K, V, Q>(leaf: &Leaf<K, V>, h: u64, k: &Q) -> KeyLoc
 where
     K: Hash + Eq + Clone + Debug + Borrow<Q>,
     V: Clone,
-    Q: Eq,
+    Q: Eq + ?Sized,
 {
     debug_assert!(h < u64::MAX);
 
@@ -213,11 +213,11 @@ where
 }
 
 #[cfg(feature = "simd_support")]
-pub(crate) fn leaf_simd_search<K, V, Q: ?Sized>(leaf: &Leaf<K, V>, h: u64, k: &Q) -> KeyLoc
+pub(crate) fn leaf_simd_search<K, V, Q>(leaf: &Leaf<K, V>, h: u64, k: &Q) -> KeyLoc
 where
     K: Hash + Eq + Clone + Debug + Borrow<Q>,
     V: Clone,
-    Q: Eq,
+    Q: Eq + ?Sized,
 {
     // This is an important piece of logic!
     debug_assert!(h < u64::MAX);

--- a/src/internals/lincowcell/mod.rs
+++ b/src/internals/lincowcell/mod.rs
@@ -366,7 +366,7 @@ mod tests {
                 let mut_ptr = cc_wrtxn.get_mut();
                 assert!(mut_ptr.x >= last_value);
                 last_value = mut_ptr.x;
-                mut_ptr.x = mut_ptr.x + 1;
+                mut_ptr.x += 1;
             }
             cc_wrtxn.commit();
         }
@@ -486,7 +486,7 @@ mod tests {
                 let mut cc_wrtxn = cc.write();
                 {
                     let mut_ptr = cc_wrtxn.get_mut();
-                    mut_ptr.data = mut_ptr.data + 1;
+                    mut_ptr.data += 1;
                 }
                 cc_wrtxn.commit();
             }
@@ -598,7 +598,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write();
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit();
         }
@@ -609,7 +609,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write();
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit();
         }

--- a/src/internals/lincowcell_async/mod.rs
+++ b/src/internals/lincowcell_async/mod.rs
@@ -358,7 +358,7 @@ mod tests {
                 let mut_ptr = cc_wrtxn.get_mut();
                 assert!(mut_ptr.x >= last_value);
                 last_value = mut_ptr.x;
-                mut_ptr.x = mut_ptr.x + 1;
+                mut_ptr.x += 1;
             }
             cc_wrtxn.commit().await;
         }
@@ -460,7 +460,7 @@ mod tests {
                 let mut cc_wrtxn = cc.write().await;
                 {
                     let mut_ptr = cc_wrtxn.get_mut();
-                    mut_ptr.data = mut_ptr.data + 1;
+                    mut_ptr.data += 1;
                 }
                 cc_wrtxn.commit().await;
             }
@@ -563,7 +563,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write().await;
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit().await;
         }
@@ -574,7 +574,7 @@ mod tests_linear {
             let mut cc_wrtxn = cc.write().await;
             {
                 let mut_ptr = cc_wrtxn.get_mut();
-                mut_ptr.data = mut_ptr.data + 1;
+                mut_ptr.data += 1;
             }
             cc_wrtxn.commit().await;
         }

--- a/src/threadcache/mod.rs
+++ b/src/threadcache/mod.rs
@@ -98,10 +98,7 @@ where
         assert!(threads > 0);
         let capacity = NonZeroUsize::new(capacity).unwrap();
 
-        let (txs, rxs): (Vec<_>, Vec<_>) = (0..threads)
-            .into_iter()
-            .map(|_| channel::<Invalidate<K>>())
-            .unzip();
+        let (txs, rxs): (Vec<_>, Vec<_>) = (0..threads).map(|_| channel::<Invalidate<K>>()).unzip();
 
         // Create an Arc<Mutex<txs>> for the writer.
         let inv_up_to_txid = Arc::new(AtomicU64::new(0));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -65,10 +65,10 @@ pub(crate) unsafe fn slice_slide<T>(slice: &mut [T], idx: usize, count: usize) {
 }
 */
 
-pub(crate) fn slice_search_linear<K, Q: ?Sized>(slice: &[K], k: &Q) -> Result<usize, usize>
+pub(crate) fn slice_search_linear<K, Q>(slice: &[K], k: &Q) -> Result<usize, usize>
 where
     K: Borrow<Q>,
-    Q: Ord,
+    Q: Ord + ?Sized,
 {
     for (idx, nk) in slice.iter().enumerate() {
         let r = k.cmp(nk.borrow());


### PR DESCRIPTION
The implementation of `Deserialize` is based on the implementation of `Extend`.

I can of course remove the first commit as it is admittedly unrelated and unnecessary for Serde support, it just felt better working in a code base that starts without Clippy warnings and stays that way.