### PR TITLE
RFC: Make LinCowCell::read sync as it never blocks

### DIFF
--- a/src/bptree/asynch.rs
+++ b/src/bptree/asynch.rs
@@ -44,7 +44,7 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
 }
 
 #[cfg(feature = "serde")]
-impl<K, V> Serialize for BptreeMapReadTxn<'_, K, V>
+impl<K, V> Serialize for BptreeMap<K, V>
 where
     K: Serialize + Clone + Ord + Debug + Sync + Send + 'static,
     V: Serialize + Clone + Sync + Send + 'static,
@@ -53,9 +53,11 @@ where
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_map(Some(self.len()))?;
+        let txn = self.read();
 
-        for (key, val) in self.iter() {
+        let mut state = serializer.serialize_map(Some(txn.len()))?;
+
+        for (key, val) in txn.iter() {
             state.serialize_entry(key, val)?;
         }
 
@@ -325,7 +327,7 @@ mod tests {
     async fn test_bptree2_serialize_deserialize() {
         let map: BptreeMap<usize, usize> = vec![(10, 11), (15, 16), (20, 21)].into_iter().collect();
 
-        let value = serde_json::to_value(&map.read()).unwrap();
+        let value = serde_json::to_value(&map).unwrap();
         assert_eq!(value, serde_json::json!({ "10": 11, "15": 16, "20": 21 }));
 
         let map: BptreeMap<usize, usize> = serde_json::from_value(value).unwrap();

--- a/src/hashmap/asynch.rs
+++ b/src/hashmap/asynch.rs
@@ -30,8 +30,8 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Initiate a read transaction for the Hashmap, concurrent to any
     /// other readers or writers.
-    pub async fn read<'x>(&'x self) -> HashMapReadTxn<'x, K, V> {
-        let inner = self.inner.read().await;
+    pub fn read<'x>(&'x self) -> HashMapReadTxn<'x, K, V> {
+        let inner = self.inner.read();
         HashMapReadTxn { inner }
     }
 
@@ -58,8 +58,8 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     /// will be able to percieve these changes.
     ///
     /// To abort (unstage changes), just do not call this function.
-    pub async fn commit(self) {
-        self.inner.commit().await;
+    pub fn commit(self) {
+        self.inner.commit();
     }
 }
 
@@ -129,7 +129,7 @@ mod tests {
         hmap_write.clear();
         assert!(!hmap_write.contains_key(&10));
         assert!(!hmap_write.contains_key(&15));
-        hmap_write.commit().await;
+        hmap_write.commit();
     }
 
     #[tokio::test]
@@ -138,22 +138,22 @@ mod tests {
         let mut hmap_w1 = hmap.write().await;
         hmap_w1.insert(10, 10);
         hmap_w1.insert(15, 15);
-        hmap_w1.commit().await;
+        hmap_w1.commit();
 
-        let hmap_r1 = hmap.read().await;
+        let hmap_r1 = hmap.read();
         assert!(hmap_r1.contains_key(&10));
         assert!(hmap_r1.contains_key(&15));
         assert!(!hmap_r1.contains_key(&20));
 
         let mut hmap_w2 = hmap.write().await;
         hmap_w2.insert(20, 20);
-        hmap_w2.commit().await;
+        hmap_w2.commit();
 
         assert!(hmap_r1.contains_key(&10));
         assert!(hmap_r1.contains_key(&15));
         assert!(!hmap_r1.contains_key(&20));
 
-        let hmap_r2 = hmap.read().await;
+        let hmap_r2 = hmap.read();
         assert!(hmap_r2.contains_key(&10));
         assert!(hmap_r2.contains_key(&15));
         assert!(hmap_r2.contains_key(&20));
@@ -187,7 +187,7 @@ mod tests {
     #[tokio::test]
     async fn test_hashmap_from_iter() {
         let hmap: HashMap<usize, usize> = vec![(10, 10), (15, 15), (20, 20)].into_iter().collect();
-        let hmap_r2 = hmap.read().await;
+        let hmap_r2 = hmap.read();
         assert!(hmap_r2.contains_key(&10));
         assert!(hmap_r2.contains_key(&15));
         assert!(hmap_r2.contains_key(&20));
@@ -198,12 +198,11 @@ mod tests {
     async fn test_hashmap_serialize_deserialize() {
         let hmap: HashMap<usize, usize> = vec![(10, 11), (15, 16), (20, 21)].into_iter().collect();
 
-        let value = serde_json::to_value(&hmap.read().await).unwrap();
+        let value = serde_json::to_value(&hmap.read()).unwrap();
         assert_eq!(value, serde_json::json!({ "10": 11, "15": 16, "20": 21 }));
 
         let hmap: HashMap<usize, usize> = serde_json::from_value(value).unwrap();
-        let mut vec: Vec<(usize, usize)> =
-            hmap.read().await.iter().map(|(k, v)| (*k, *v)).collect();
+        let mut vec: Vec<(usize, usize)> = hmap.read().iter().map(|(k, v)| (*k, *v)).collect();
         vec.sort_unstable();
         assert_eq!(vec, [(10, 11), (15, 16), (20, 21)]);
     }

--- a/src/hashmap/asynch.rs
+++ b/src/hashmap/asynch.rs
@@ -64,7 +64,7 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 }
 
 #[cfg(feature = "serde")]
-impl<K, V> Serialize for HashMapReadTxn<'_, K, V>
+impl<K, V> Serialize for HashMap<K, V>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Serialize + Clone + Sync + Send + 'static,
@@ -73,9 +73,11 @@ where
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_map(Some(self.len()))?;
+        let txn = self.read();
 
-        for (key, val) in self.iter() {
+        let mut state = serializer.serialize_map(Some(txn.len()))?;
+
+        for (key, val) in txn.iter() {
             state.serialize_entry(key, val)?;
         }
 
@@ -198,7 +200,7 @@ mod tests {
     async fn test_hashmap_serialize_deserialize() {
         let hmap: HashMap<usize, usize> = vec![(10, 11), (15, 16), (20, 21)].into_iter().collect();
 
-        let value = serde_json::to_value(&hmap.read()).unwrap();
+        let value = serde_json::to_value(&hmap).unwrap();
         assert_eq!(value, serde_json::json!({ "10": 11, "15": 16, "20": 21 }));
 
         let hmap: HashMap<usize, usize> = serde_json::from_value(value).unwrap();

--- a/src/hashtrie/asynch.rs
+++ b/src/hashtrie/asynch.rs
@@ -64,7 +64,7 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 }
 
 #[cfg(feature = "serde")]
-impl<K, V> Serialize for HashTrieReadTxn<'_, K, V>
+impl<K, V> Serialize for HashTrie<K, V>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Serialize + Clone + Sync + Send + 'static,
@@ -73,9 +73,11 @@ where
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_map(Some(self.len()))?;
+        let txn = self.read();
 
-        for (key, val) in self.iter() {
+        let mut state = serializer.serialize_map(Some(txn.len()))?;
+
+        for (key, val) in txn.iter() {
             state.serialize_entry(key, val)?;
         }
 
@@ -198,7 +200,7 @@ mod tests {
     async fn test_hashtrie_serialize_deserialize() {
         let hmap: HashTrie<usize, usize> = vec![(10, 11), (15, 16), (20, 21)].into_iter().collect();
 
-        let value = serde_json::to_value(&hmap.read()).unwrap();
+        let value = serde_json::to_value(&hmap).unwrap();
         assert_eq!(value, serde_json::json!({ "10": 11, "15": 16, "20": 21 }));
 
         let hmap: HashTrie<usize, usize> = serde_json::from_value(value).unwrap();

--- a/src/hashtrie/asynch.rs
+++ b/src/hashtrie/asynch.rs
@@ -30,8 +30,8 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Initiate a read transaction for the Hashmap, concurrent to any
     /// other readers or writers.
-    pub async fn read<'x>(&'x self) -> HashTrieReadTxn<'x, K, V> {
-        let inner = self.inner.read().await;
+    pub fn read<'x>(&'x self) -> HashTrieReadTxn<'x, K, V> {
+        let inner = self.inner.read();
         HashTrieReadTxn { inner }
     }
 
@@ -58,8 +58,8 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     /// will be able to percieve these changes.
     ///
     /// To abort (unstage changes), just do not call this function.
-    pub async fn commit(self) {
-        self.inner.commit().await;
+    pub fn commit(self) {
+        self.inner.commit();
     }
 }
 
@@ -129,7 +129,7 @@ mod tests {
         hmap_write.clear();
         assert!(!hmap_write.contains_key(&10));
         assert!(!hmap_write.contains_key(&15));
-        hmap_write.commit().await;
+        hmap_write.commit();
     }
 
     #[tokio::test]
@@ -138,22 +138,22 @@ mod tests {
         let mut hmap_w1 = hmap.write().await;
         hmap_w1.insert(10, 10);
         hmap_w1.insert(15, 15);
-        hmap_w1.commit().await;
+        hmap_w1.commit();
 
-        let hmap_r1 = hmap.read().await;
+        let hmap_r1 = hmap.read();
         assert!(hmap_r1.contains_key(&10));
         assert!(hmap_r1.contains_key(&15));
         assert!(!hmap_r1.contains_key(&20));
 
         let mut hmap_w2 = hmap.write().await;
         hmap_w2.insert(20, 20);
-        hmap_w2.commit().await;
+        hmap_w2.commit();
 
         assert!(hmap_r1.contains_key(&10));
         assert!(hmap_r1.contains_key(&15));
         assert!(!hmap_r1.contains_key(&20));
 
-        let hmap_r2 = hmap.read().await;
+        let hmap_r2 = hmap.read();
         assert!(hmap_r2.contains_key(&10));
         assert!(hmap_r2.contains_key(&15));
         assert!(hmap_r2.contains_key(&20));
@@ -187,7 +187,7 @@ mod tests {
     #[tokio::test]
     async fn test_hashtrie_from_iter() {
         let hmap: HashTrie<usize, usize> = vec![(10, 10), (15, 15), (20, 20)].into_iter().collect();
-        let hmap_r2 = hmap.read().await;
+        let hmap_r2 = hmap.read();
         assert!(hmap_r2.contains_key(&10));
         assert!(hmap_r2.contains_key(&15));
         assert!(hmap_r2.contains_key(&20));
@@ -198,12 +198,11 @@ mod tests {
     async fn test_hashtrie_serialize_deserialize() {
         let hmap: HashTrie<usize, usize> = vec![(10, 11), (15, 16), (20, 21)].into_iter().collect();
 
-        let value = serde_json::to_value(&hmap.read().await).unwrap();
+        let value = serde_json::to_value(&hmap.read()).unwrap();
         assert_eq!(value, serde_json::json!({ "10": 11, "15": 16, "20": 21 }));
 
         let hmap: HashTrie<usize, usize> = serde_json::from_value(value).unwrap();
-        let mut vec: Vec<(usize, usize)> =
-            hmap.read().await.iter().map(|(k, v)| (*k, *v)).collect();
+        let mut vec: Vec<(usize, usize)> = hmap.read().iter().map(|(k, v)| (*k, *v)).collect();
         vec.sort_unstable();
         assert_eq!(vec, [(10, 11), (15, 16), (20, 21)]);
     }


### PR DESCRIPTION
Using MVCC, readers never have to wait for writers and hence opening a read transaction never blocks. We should therefore be able to make `LinCowCell::read` sync by using a `SyncMutex` for its `active` field. This then implies that `LinCowCellWriteTxn::commit` can also become sync and onyl the potentially blocking `LinCowCell::write` has to stay async so that one writer can yield to others.

This does imply a change to the `test_concurrent_create` test case as the readers are now fully blocking code that never yields to the executor and the first one will hence starve all other readers and the writers so that the test case never finishes. This is mitigating by using `spawn_blocking` for these actually blocking tasks. Alternatively, they could be forced to yield using `yield_now` or spawned onto a multi-threaded runtimes with at least one more worker thread than reader tasks.