### PR TITLE
Enable serialization of both collections and read transactions

### DIFF
--- a/src/bptree/mod.rs
+++ b/src/bptree/mod.rs
@@ -47,6 +47,26 @@ impl<K: Clone + Ord + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 's
 }
 
 #[cfg(feature = "serde")]
+impl<K, V> Serialize for BptreeMapReadTxn<'_, K, V>
+where
+    K: Serialize + Clone + Ord + Debug + Sync + Send + 'static,
+    V: Serialize + Clone + Sync + Send + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(self.len()))?;
+
+        for (key, val) in self.iter() {
+            state.serialize_entry(key, val)?;
+        }
+
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<K, V> Serialize for BptreeMap<K, V>
 where
     K: Serialize + Clone + Ord + Debug + Sync + Send + 'static,
@@ -56,15 +76,7 @@ where
     where
         S: Serializer,
     {
-        let txn = self.read();
-
-        let mut state = serializer.serialize_map(Some(txn.len()))?;
-
-        for (key, val) in txn.iter() {
-            state.serialize_entry(key, val)?;
-        }
-
-        state.end()
+        self.read().serialize(serializer)
     }
 }
 

--- a/src/hashmap/asynch.rs
+++ b/src/hashmap/asynch.rs
@@ -64,6 +64,26 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 }
 
 #[cfg(feature = "serde")]
+impl<K, V> Serialize for HashMapReadTxn<'_, K, V>
+where
+    K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
+    V: Serialize + Clone + Sync + Send + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(self.len()))?;
+
+        for (key, val) in self.iter() {
+            state.serialize_entry(key, val)?;
+        }
+
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<K, V> Serialize for HashMap<K, V>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
@@ -73,15 +93,7 @@ where
     where
         S: Serializer,
     {
-        let txn = self.read();
-
-        let mut state = serializer.serialize_map(Some(txn.len()))?;
-
-        for (key, val) in txn.iter() {
-            state.serialize_entry(key, val)?;
-        }
-
-        state.end()
+        self.read().serialize(serializer)
     }
 }
 

--- a/src/hashmap/mod.rs
+++ b/src/hashmap/mod.rs
@@ -128,6 +128,26 @@ impl<
 */
 
 #[cfg(feature = "serde")]
+impl<K, V> Serialize for HashMapReadTxn<'_, K, V>
+where
+    K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
+    V: Serialize + Clone + Sync + Send + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(self.len()))?;
+
+        for (key, val) in self.iter() {
+            state.serialize_entry(key, val)?;
+        }
+
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<K, V> Serialize for HashMap<K, V>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
@@ -137,15 +157,7 @@ where
     where
         S: Serializer,
     {
-        let txn = self.read();
-
-        let mut state = serializer.serialize_map(Some(txn.len()))?;
-
-        for (key, val) in txn.iter() {
-            state.serialize_entry(key, val)?;
-        }
-
-        state.end()
+        self.read().serialize(serializer)
     }
 }
 

--- a/src/hashtrie/asynch.rs
+++ b/src/hashtrie/asynch.rs
@@ -64,6 +64,26 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 }
 
 #[cfg(feature = "serde")]
+impl<K, V> Serialize for HashTrieReadTxn<'_, K, V>
+where
+    K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
+    V: Serialize + Clone + Sync + Send + 'static,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_map(Some(self.len()))?;
+
+        for (key, val) in self.iter() {
+            state.serialize_entry(key, val)?;
+        }
+
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
 impl<K, V> Serialize for HashTrie<K, V>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
@@ -73,15 +93,7 @@ where
     where
         S: Serializer,
     {
-        let txn = self.read();
-
-        let mut state = serializer.serialize_map(Some(txn.len()))?;
-
-        for (key, val) in txn.iter() {
-            state.serialize_entry(key, val)?;
-        }
-
-        state.end()
+        self.read().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
Serialization of read transactions can be required to ensure consistency, i.e. storing the same information elsewhere as was written to the serialized representation.