### PR TITLE
v5.2 - Resolve memory leak in arcache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,13 +29,18 @@ arcache = ["maps", "lru", "crossbeam-queue"]
 skinny = []
 hashtrie_skinny = []
 
-default = ["asynch", "ahash", "ebr", "maps", "arcache"]
+default = ["asynch", "ahash", "ebr", "maps", "arcache-is-hashtrie"]
+dhat-heap = ["dep:dhat"]
+
+arcache-is-hashmap = ["arcache"]
+arcache-is-hashtrie = ["arcache"]
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
 crossbeam-utils = { version = "0.8.12", optional = true }
 crossbeam-epoch = { version = "0.9.11", optional = true }
 crossbeam-queue = { version = "0.3.6", optional = true }
+dhat = { version = "0.3.3", optional = true }
 lru = { version = "0.12", optional = true }
 serde = { version = "1.0", optional = true }
 smallvec = { version = "1.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concread"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["William Brown <william@blackhats.net.au>"]
 edition = "2021"
 description = "Concurrently Readable Data-Structures for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ tracing = "0.1"
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 rand = "0.8"
-time = "0.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "std", "fmt"] }
 uuid = "1.0"
 function_name = "0.3"

--- a/src/cowcell/mod.rs
+++ b/src/cowcell/mod.rs
@@ -234,6 +234,7 @@ where
 mod tests {
     use super::CowCell;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Instant;
 
     use std::thread::scope;
 
@@ -301,7 +302,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_multithread_create() {
-        let start = time::Instant::now();
+        let start = Instant::now();
         // Create the new cowcell.
         let data: i64 = 0;
         let cc = CowCell::new(data);
@@ -352,7 +353,7 @@ mod tests {
             true
         }));
 
-        let end = time::Instant::now();
+        let end = Instant::now();
         print!("Arc MT create :{:?} ", end - start);
     }
 

--- a/src/ebrcell/mod.rs
+++ b/src/ebrcell/mod.rs
@@ -334,7 +334,9 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_multithread_create() {
-        let start = time::Instant::now();
+        use std::time::Instant;
+
+        let start = Instant::now();
         // Create the new ebrcell.
         let data: i64 = 0;
         let cc = EbrCell::new(data);
@@ -384,7 +386,7 @@ mod tests {
             true
         }));
 
-        let end = time::Instant::now();
+        let end = Instant::now();
         print!("Ebr MT create :{:?} ", end - start);
     }
 

--- a/src/hashmap/mod.rs
+++ b/src/hashmap/mod.rs
@@ -31,6 +31,9 @@ use serde::{
 #[cfg(feature = "serde")]
 use crate::utils::MapCollector;
 
+#[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
+use crate::internals::hashmap::cursor::Datum;
+
 use crate::internals::lincowcell::{LinCowCell, LinCowCellReadTxn, LinCowCellWriteTxn};
 
 include!("impl.rs");
@@ -72,13 +75,12 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
     HashMapWriteTxn<'_, K, V>
 {
-    /*
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
     pub(crate) fn get_txid(&self) -> u64 {
         self.inner.as_ref().get_txid()
     }
-    */
 
-    /*
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
     pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
@@ -86,17 +88,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     {
         self.inner.as_ref().hash_key(k)
     }
-    */
 
-    /*
     /// This is *unsafe* because changing the key CAN and WILL break hashing, which can
     /// have serious consequences. This API only exists to allow arcache to access the inner
     /// content of the slot to simplify its API. You should basically never touch this
     /// function as it's the HashMap equivalent of the demon sphere.
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
     pub(crate) unsafe fn get_slot_mut(&mut self, k_hash: u64) -> Option<&mut [Datum<K, V>]> {
         self.inner.as_mut().get_slot_mut_ref(k_hash)
     }
-    */
 
     /// Commit the changes from this write transaction. Readers after this point
     /// will be able to percieve these changes.
@@ -107,16 +107,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 }
 
-/*
-impl<
-        K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
-        V: Clone + Sync + Send + 'static,
-    > HashMapReadTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
+    HashMapReadTxn<'_, K, V>
 {
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
     pub(crate) fn get_txid(&self) -> u64 {
         self.inner.as_ref().get_txid()
     }
 
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashmap"))]
     pub(crate) fn prehash<Q: ?Sized>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
@@ -125,7 +124,6 @@ impl<
         self.inner.as_ref().hash_key(k)
     }
 }
-*/
 
 #[cfg(feature = "serde")]
 impl<K, V> Serialize for HashMapReadTxn<'_, K, V>

--- a/src/hashtrie/mod.rs
+++ b/src/hashtrie/mod.rs
@@ -33,7 +33,7 @@ use serde::{
     ser::{Serialize, SerializeMap, Serializer},
 };
 
-#[cfg(feature = "arcache")]
+#[cfg(all(feature = "arcache", feature = "arcache-is-hashtrie"))]
 use crate::internals::hashtrie::cursor::Datum;
 
 #[cfg(feature = "serde")]
@@ -80,12 +80,13 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
     HashTrieWriteTxn<'_, K, V>
 {
-    #[cfg(feature = "arcache")]
-    pub(crate) fn get_txid(&self) -> u64 {
+    /// View the current transaction ID for this cache. This is a monotonically increasing
+    /// value. If two transactions have the same txid, they are the same data generation.
+    pub fn get_txid(&self) -> u64 {
         self.inner.as_ref().get_txid()
     }
 
-    #[cfg(feature = "arcache")]
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashtrie"))]
     pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,
@@ -98,7 +99,7 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     /// have serious consequences. This API only exists to allow arcache to access the inner
     /// content of the slot to simplify its API. You should basically never touch this
     /// function as it's the HashTrie equivalent of a the demon sphere.
-    #[cfg(feature = "arcache")]
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashtrie"))]
     pub(crate) unsafe fn get_slot_mut(&mut self, k_hash: u64) -> Option<&mut [Datum<K, V>]> {
         self.inner.as_mut().get_slot_mut_ref(k_hash)
     }
@@ -115,12 +116,13 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
     HashTrieReadTxn<'_, K, V>
 {
-    #[cfg(feature = "arcache")]
-    pub(crate) fn get_txid(&self) -> u64 {
+    /// View the current transaction ID for this cache. This is a monotonically increasing
+    /// value. If two transactions have the same txid, they are the same data generation.
+    pub fn get_txid(&self) -> u64 {
         self.inner.as_ref().get_txid()
     }
 
-    #[cfg(feature = "arcache")]
+    #[cfg(all(feature = "arcache", feature = "arcache-is-hashtrie"))]
     pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
     where
         K: Borrow<Q>,

--- a/src/internals/hashmap/cursor.rs
+++ b/src/internals/hashmap/cursor.rs
@@ -451,7 +451,7 @@ impl<K: Clone + Hash + Eq + Debug, V: Clone> CursorWrite<K, V> {
         path_get_mut_ref(self.root, h, k)
     }
 
-    /*
+    #[allow(dead_code)]
     pub(crate) unsafe fn get_slot_mut_ref(&mut self, h: u64) -> Option<&mut [Datum<K, V>]> {
         match path_clone(
             self.root,
@@ -469,7 +469,6 @@ impl<K: Clone + Hash + Eq + Debug, V: Clone> CursorWrite<K, V> {
         // Now get the ref.
         path_get_slot_mut_ref(self.root, h)
     }
-    */
 
     #[cfg(test)]
     pub(crate) fn root_txid(&self) -> u64 {
@@ -1064,7 +1063,6 @@ where
     }
 }
 
-/*
 unsafe fn path_get_slot_mut_ref<'a, K: Clone + Hash + Eq + Debug, V: Clone>(
     node: *mut Node<K, V>,
     h: u64,
@@ -1089,7 +1087,6 @@ where
         r.map(|v| &mut *v as &mut [Datum<K, V>])
     }
 }
-*/
 
 #[cfg(test)]
 mod tests {

--- a/src/internals/hashmap/mod.rs
+++ b/src/internals/hashmap/mod.rs
@@ -21,6 +21,6 @@
 mod macros;
 pub mod cursor;
 pub mod iter;
-mod node;
+pub(crate) mod node;
 mod simd;
 mod states;

--- a/src/internals/hashmap/simd.rs
+++ b/src/internals/hashmap/simd.rs
@@ -108,7 +108,6 @@ where
     }
 }
 
-/*
 #[cfg(not(feature = "simd_support"))]
 pub(crate) fn leaf_simd_get_slot<K, V>(leaf: &Leaf<K, V>, h: u64) -> Option<usize>
 where
@@ -180,7 +179,6 @@ where
     }
     None
 }
-*/
 
 #[cfg(not(feature = "simd_support"))]
 pub(crate) fn leaf_simd_search<K, V, Q>(leaf: &Leaf<K, V>, h: u64, k: &Q) -> KeyLoc

--- a/src/internals/lincowcell/mod.rs
+++ b/src/internals/lincowcell/mod.rs
@@ -268,6 +268,7 @@ mod tests {
     use super::LinCowCellCapable;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::thread::scope;
+    use std::time::Instant;
 
     #[derive(Debug)]
     struct TestData {
@@ -387,7 +388,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_multithread_create() {
-        let start = time::Instant::now();
+        let start = Instant::now();
         // Create the new cowcell.
         let data = TestData { x: 0 };
         let cc = LinCowCell::new(data);
@@ -421,7 +422,7 @@ mod tests {
             true
         }));
 
-        let end = time::Instant::now();
+        let end = Instant::now();
         print!("Arc MT create :{:?} ", end - start);
     }
 

--- a/src/internals/lincowcell_async/mod.rs
+++ b/src/internals/lincowcell_async/mod.rs
@@ -378,7 +378,9 @@ mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn test_concurrent_create() {
-        let start = time::Instant::now();
+        use std::time::Instant;
+
+        let start = Instant::now();
         // Create the new cowcell.
         let data = TestData { x: 0 };
         let cc = Arc::new(LinCowCell::new(data));
@@ -404,7 +406,7 @@ mod tests {
             tokio::task::spawn(mt_writer(cc.clone())),
         );
 
-        let end = time::Instant::now();
+        let end = Instant::now();
         print!("Arc MT create :{:?} ", end - start);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,15 @@
 //! By default all of these features are enabled. If you are planning to use this crate in a wasm
 //! context we recommend you use only `maps` as a feature.
 
-// #![deny(warnings)]
-
+#![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 #![allow(clippy::needless_lifetimes)]
 #![cfg_attr(feature = "simd_support", feature(portable_simd))]
+
+#[cfg(all(test, feature = "dhat-heap"))]
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
 
 #[cfg(feature = "maps")]
 #[macro_use]


### PR DESCRIPTION
If the write miss thread local cache was enabled, a mistake existed in the case where the write thread is under high pressure which could lead to memory being leaked. Nodes are now wrapped in a safe wrapper to ensure they can not be leaked.