### PR TITLE
Fix BptreeMap range iter end condtition

### DIFF
--- a/src/bptree/mod.rs
+++ b/src/bptree/mod.rs
@@ -355,6 +355,14 @@ mod tests {
         assert_released();
     }
 
+    #[test]
+    fn test_bptree2_map_rangeiter_2() {
+        let map = BptreeMap::from_iter([(3, ()), (4, ()), (0, ())]);
+
+        let r = map.read();
+        assert!(r.range(1..=2).count() == 0);
+    }
+
     /*
     #[test]
     fn test_bptree2_map_write_compact() {

--- a/src/internals/bptree/iter.rs
+++ b/src/internals/bptree/iter.rs
@@ -561,6 +561,17 @@ where
             right_iter.clear();
         }
 
+        // If both iterators end up in the same leaf and left index is larger,
+        // it indicates that there is nothing to return
+        if let Some((lnode, lidx)) = left_iter.get_mut() {
+            if let Some((rnode, ridx)) = right_iter.get_mut() {
+                if rnode == lnode && lidx > ridx {
+                    right_iter.clear();
+                    left_iter.clear();
+                }
+            }
+        }
+
         RangeIter {
             length,
             left_iter,


### PR DESCRIPTION
Fix for #118.

The problem was that end condition was not checked correctly when both leaf iterators ended up in the same leaf.

I've also tried to add [`proptest`](https://github.com/proptest-rs/proptest) test to check consistency in `range` iter of `concread::BptreeMap` and `std::collections::BTreeMap`. 
Can make separate PR if it's something desirable for this crate.