### PR TITLE
Limit the size of the haunted set.

### DIFF
--- a/src/arcache/ll.rs
+++ b/src/arcache/ll.rs
@@ -323,7 +323,16 @@ where
         self.size
     }
 
-    #[cfg(test)]
+    pub(crate) fn drop_head(&mut self) {
+        assert!(self.size > 0);
+        let next = unsafe { (*self.head).next };
+        if next != self.tail {
+            let mut owned = self.pop();
+            let n = owned.into_inner();
+            LLNode::free(n);
+        }
+    }
+
     pub(crate) fn peek_head(&self) -> Option<&K> {
         debug_assert!(!self.head.is_null());
         let next = unsafe { (*self.head).next };

--- a/src/arcache/stats.rs
+++ b/src/arcache/stats.rs
@@ -3,55 +3,91 @@ use std::fmt::Debug;
 /// Write statistics for ARCache
 pub trait ARCacheWriteStat<K> {
     // RW phase trackers
-    /// _
+    /// Record that a cache clear event occured.
+    ///
+    /// Phase - write transaction open
     fn cache_clear(&mut self) {}
 
-    /// _
+    /// Record a cache read event.
+    ///
+    /// Phase - write transaction open
     fn cache_read(&mut self) {}
 
-    /// _
+    /// Record a cache hit event.
+    ///
+    /// Phase - write transaction open
     fn cache_hit(&mut self) {}
 
     // Commit phase trackers
 
-    /// _
+    /// Record an include event from a reading transaction that was successfully added
+    /// to the cache.
+    ///
+    /// Phase - write transaction committing
     fn include(&mut self, _k: &K) {}
 
-    /// _
+    /// Record an include event to the haunted set - this indicates a reader included
+    /// an item that we already included.
+    ///
+    /// Phase - write transaction committing
     fn include_haunted(&mut self, k: &K) {
         self.include(k)
     }
 
-    /// _
+    /// Record an item was modified
+    ///
+    /// Phase - write transaction committing
     fn modify(&mut self, _k: &K) {}
 
-    /// _
+    /// Record that a member of the frequent ghost set was revived
+    ///
+    /// Phase - write transaction committing
     fn ghost_frequent_revive(&mut self, _k: &K) {}
 
-    /// _
+    /// Record that a member of the recent ghost set was revived
+    ///
+    /// Phase - write transaction committing
     fn ghost_recent_revive(&mut self, _k: &K) {}
 
-    /// _
+    /// Record items that are evicted from the recent set
+    ///
+    /// Phase - write transaction committing
     fn evict_from_recent(&mut self, _k: &K) {}
 
-    /// _
+    /// Record items that are evicted from the frequent set
+    ///
+    /// Phase - write transaction committing
     fn evict_from_frequent(&mut self, _k: &K) {}
 
     // Size of things after the operation.
 
-    /// _
+    /// Return the current p_weight of the cache - p_weight indicates the bias toward
+    /// the recent set. A p of 0 indicates that the cache is fully weighted to to the
+    /// frequent set. A p of `max` cache size indicates the cache is fully weighted
+    /// to the recent set.
+    ///
+    /// Phase - commit complete
     fn p_weight(&mut self, _p: u64) {}
 
-    /// _
+    /// The current maximum size of the cache
+    ///
+    /// Phase - commit complete
     fn shared_max(&mut self, _i: u64) {}
 
-    /// _
+    /// The current size of the frequent set
+    ///
+    /// Phase - commit complete
     fn freq(&mut self, _i: u64) {}
 
-    /// _
+    /// The current size of the recent set
+    ///
+    /// Phase - commit complete
     fn recent(&mut self, _i: u64) {}
 
-    /// _
+    /// The current number of all keys in the cache - this includes the frequent, recent,
+    /// and ghost data.
+    ///
+    /// Phase - commit complete
     fn all_seen_keys(&mut self, _i: u64) {}
 }
 

--- a/src/internals/bptree/node.rs
+++ b/src/internals/bptree/node.rs
@@ -593,7 +593,7 @@ impl<K: Ord + Clone + Debug, V: Clone> Leaf<K, V> {
         unsafe { &*self.key[0].as_ptr() }
     }
 
-    pub(crate) fn min_raw<'a>(pointer: *const Self) -> *const K {
+    pub(crate) fn min_raw(pointer: *const Self) -> *const K {
         unsafe { &*pointer }.min()
     }
 
@@ -863,9 +863,9 @@ impl<K: Ord + Clone + Debug, V: Clone> Leaf<K, V> {
         if count == 0 {
             return true;
         }
-        let mut lk: &K = unsafe { &*(&*pointer).key[0].as_ptr() };
+        let mut lk: &K = unsafe { &*(*pointer).key[0].as_ptr() };
         for work_idx in 1..count {
-            let rk: &K = unsafe { &*(&*pointer).key[work_idx].as_ptr() };
+            let rk: &K = unsafe { &*(*pointer).key[work_idx].as_ptr() };
             if lk >= rk {
                 // println!("{:?}", self);
                 if cfg!(test) {
@@ -964,7 +964,7 @@ impl<K: Ord + Clone + Debug, V: Clone> Branch<K, V> {
         unsafe { (*self.nodes[0]).min() }
     }
 
-    pub(crate) fn min_raw<'a>(pointer: *const Self) -> *const K {
+    pub(crate) fn min_raw(pointer: *const Self) -> *const K {
         let this = unsafe { &*pointer };
         debug_assert_branch!(this);
         Node::min_raw(this.nodes[0])


### PR DESCRIPTION
The haunted set of the cache exists to provide temporal consistency of keys that have been seen in the cache. This is because a read transaction of an older transaction generation may attempt to include a value to the cache that has been deleted or modified. To prevent this evicted items are sent to the haunted list, which retains the key and the eviction transaction id. This way any inclusion event that is older than the caches haunted item transaction id will be ignored.

These haunted sets however can become very large with a high number of keys and especially if the keys and values are nearly the same size.

As the value of the haunted items "diminishes" over time, and we already have the ability to deny includes older than a minimum transaction id (as part of cache clearing) we can re-use these mechanisms to trim the haunted set.

This way the haunted set may only contain entries that are within the look back limit, or the number of transaction in the past that we allow to be used.

A lower look back limit means that the haunted sets are smaller, but cache accuracy may be lower as we can no longer use older transactions data. A higher look back limit means the haunted sets are larger but cache accuracy can improve as we can include a range of transactions inclusions and hit metrics.

The default value for this tries to balance this for highly parallel and concurrent workloads. Workloads will long running transactions will benefit from a larger look back limit, a work load with smaller transaction lifes likely needs no changes.

Fixes #128 