### PR TITLE
Change default hasher to foldhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,12 @@ name = "concread"
 path = "src/lib.rs"
 
 [features]
-default = ["asynch", "ahash", "ebr", "maps", "arcache-is-hashtrie"]
+default = ["asynch", "foldhash", "ebr", "maps", "arcache-is-hashtrie"]
 
 # Features to add/remove contents.
 ahash = ["dep:ahash"]
+foldhash = ["dep:foldhash"]
+
 arcache = ["maps", "lru", "crossbeam-queue"]
 asynch = ["tokio"]
 ebr = ["crossbeam-epoch"]
@@ -44,6 +46,7 @@ simd_support = []
 
 [dependencies]
 ahash = { version = "0.8", optional = true }
+foldhash = { version = "0.1.5", optional = true }
 crossbeam-utils = { version = "0.8.21", optional = true }
 crossbeam-epoch = { version = "0.9.11", optional = true }
 crossbeam-queue = { version = "0.3.12", optional = true }

--- a/src/internals/hashmap/cursor.rs
+++ b/src/internals/hashmap/cursor.rs
@@ -11,7 +11,11 @@ use std::mem;
 
 #[cfg(feature = "ahash")]
 use ahash::RandomState;
-#[cfg(not(feature = "ahash"))]
+
+#[cfg(feature = "foldhash")]
+use foldhash::fast::RandomState;
+
+#[cfg(all(not(feature = "ahash"), not(feature = "foldhash")))]
 use std::collections::hash_map::RandomState;
 
 use std::hash::{BuildHasher, Hash, Hasher};
@@ -101,7 +105,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> SuperBlock<K, V> {
             root: leaf as *mut Node<K, V>,
             size: 0,
             txid: 1,
-            build_hasher: RandomState::new(),
+            build_hasher: RandomState::default(),
         }
     }
 
@@ -128,7 +132,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> SuperBlock<K, V> {
             txid,
             size,
             root,
-            build_hasher: RandomState::new(),
+            build_hasher: RandomState::default(),
         }
     }
 }

--- a/src/internals/hashtrie/cursor.rs
+++ b/src/internals/hashtrie/cursor.rs
@@ -20,7 +20,11 @@ use super::iter::*;
 
 #[cfg(feature = "ahash")]
 use ahash::RandomState;
-#[cfg(not(feature = "ahash"))]
+
+#[cfg(feature = "foldhash")]
+use foldhash::fast::RandomState;
+
+#[cfg(all(not(feature = "ahash"), not(feature = "foldhash")))]
 use std::collections::hash_map::RandomState;
 
 use std::hash::{BuildHasher, Hash, Hasher};
@@ -425,7 +429,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> SuperBlock<K, V> {
             root,
             length: 0,
             txid: 1,
-            build_hasher: RandomState::new(),
+            build_hasher: RandomState::default(),
             k: PhantomData,
             v: PhantomData,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@
 //! * `ebr` - epoch based reclaim cell
 //! * `maps` - concurrently readable b+tree and hashmaps
 //! * `arcache` - concurrently readable ARC cache
-//! * `ahash` - use the cpu accelerated ahash crate
 //!
 //! By default all of these features are enabled. If you are planning to use this crate in a wasm
 //! context we recommend you use only `maps` as a feature.


### PR DESCRIPTION
Following hashbrown, change the default hasher from ahash to foldhash for a performance improvement. 