### PR TITLE
`no_std` Proof of Concept implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "rust-analyzer.cargo.allTargets": true,
-    "rust-analyzer.check.features": ["default"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "rust-analyzer.cargo.allTargets": true,
+    "rust-analyzer.check.features": ["default"]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ tcache = []
 std = ["ahash/std", "ahash/runtime-rng", "crossbeam-epoch/std", "crossbeam-queue/std", "crossbeam-utils/std",  "tracing/std", "dep:parking_lot", "smallvec/write"]
 #serde = ["lock_api/serde"]
 
-no_std = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc", "serde/alloc", "dep:spin", "ahash", "arc-swap/experimental-thread-local"]
+no_std = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc", "serde/alloc", "dep:spin", "ahash"]
 
 # Internal features for tweaking some align/perf behaviours.
 dhat-heap = ["dep:dhat"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,19 @@ name = "concread"
 path = "src/lib.rs"
 
 [features]
-default = ["asynch", "ahash", "ebr", "maps", "arcache-is-hashtrie"]
+default = ["std", "asynch","ahash", "ebr", "maps", "arcache-is-hashtrie"]
 
 # Features to add/remove contents.
 ahash = ["dep:ahash"]
 arcache = ["maps", "lru", "crossbeam-queue"]
-asynch = ["tokio"]
-ebr = ["crossbeam-epoch"]
-maps = ["crossbeam-utils", "smallvec"]
+asynch = ["dep:tokio", "std"]
+ebr = ["std"]
+maps = ["dep:crossbeam-utils", "smallvec"]
 tcache = []
+std = ["ahash/std", "ahash/runtime-rng", "crossbeam-epoch/std", "crossbeam-queue/std", "crossbeam-utils/std",  "tracing/std", "dep:parking_lot", "smallvec/write"]
+#serde = ["lock_api/serde"]
+
+no_std = ["crossbeam-epoch/alloc", "crossbeam-queue/alloc", "serde/alloc", "dep:spin", "ahash", "arc-swap/experimental-thread-local"]
 
 # Internal features for tweaking some align/perf behaviours.
 dhat-heap = ["dep:dhat"]
@@ -43,21 +47,25 @@ arcache-is-hashtrie = ["arcache"]
 simd_support = []
 
 [dependencies]
-ahash = { version = "0.8", optional = true }
-crossbeam-utils = { version = "0.8.21", optional = true }
-crossbeam-epoch = { version = "0.9.11", optional = true }
-crossbeam-queue = { version = "0.3.12", optional = true }
+ahash = { version = "0.8", default-features = false, optional = true}
+crossbeam-utils = { version = "0.8.21", optional = true, default-features = false, features = []}
+crossbeam-epoch = { version = "0.9.11", optional = true, default-features = false, features = [] }
+crossbeam-queue = { version = "0.3.12", optional = true, default-features = false, features = [] }
 dhat = { version = "0.3.3", optional = true }
-lru = { version = "0.13", optional = true }
-serde = { version = "1.0", optional = true }
-smallvec = { version = "1.14", optional = true }
-sptr = "0.3"
-arc-swap = "1.0"
+lru = { version = "0.16.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false, features = []}
+smallvec = { version = "1.14", optional = true, default-features = false}
+arc-swap = {version = "1.0", default-features = false}
 tokio = { version = "1", features = ["sync"], optional = true }
-tracing = "0.1"
+tracing = {version = "0.1", default-features = false}
+lock_api = "0.4"
+parking_lot = {version = "0.12.3", optional = true }
+hashbrown = {version = "0.15.2", default-features = false}
+spin = {version = "0.10.0", optional = true, default-features = false, features = ["lock_api", "spin_mutex", "rwlock"]}
+cfg-if = "1.0.0"
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6.0", features = ["html_reports"] }
 rand = "0.9"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",

--- a/benches/hashmap_benchmark.rs
+++ b/benches/hashmap_benchmark.rs
@@ -20,6 +20,7 @@ extern crate rand;
 
 use concread::hashmap::*;
 use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use lock_api::RawMutex;
 use rand::{thread_rng, Rng};
 
 // ranges of counts for different benchmarks (MINs are inclusive, MAXes exclusive):
@@ -165,10 +166,10 @@ criterion_main!(insert, remove, search);
 
 // Utility functions:
 
-fn insert_vec<V: Clone + Sync + Send + 'static>(
-    map: &mut HashMap<u32, V>,
+fn insert_vec<V: Clone + Sync + Send + 'static, M: RawMutex + 'static>(
+    map: &mut HashMap<u32, V, M>,
     list: Vec<(u32, V)>,
-) -> HashMapWriteTxn<u32, V> {
+) -> HashMapWriteTxn<u32, V, M> {
     let mut write_txn = map.write();
     for (key, val) in list.into_iter() {
         write_txn.insert(key, val);
@@ -176,10 +177,10 @@ fn insert_vec<V: Clone + Sync + Send + 'static>(
     write_txn
 }
 
-fn remove_vec<'a, V: Clone + Sync + Send + 'static>(
-    map: &'a mut HashMap<u32, V>,
+fn remove_vec<'a, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>(
+    map: &'a mut HashMap<u32, V, M>,
     list: &Vec<u32>,
-) -> HashMapWriteTxn<'a, u32, V> {
+) -> HashMapWriteTxn<'a, u32, V, M> {
     let mut write_txn = map.write();
     for i in list.iter() {
         write_txn.remove(i);

--- a/src/arcache/ll.rs
+++ b/src/arcache/ll.rs
@@ -1,3 +1,10 @@
+
+
+#[cfg(feature = "std")]
+use std::boxed::Box;
+#[cfg(not(feature = "std"))]
+use alloc::boxed::Box;
+
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::mem::MaybeUninit;
@@ -309,10 +316,12 @@ where
             (*next).prev = prev;
             (*prev).next = next;
             // Null things for paranoia.
-            if cfg!(test) || cfg!(debug_assertions) {
+
+            cfg_if::cfg_if! { if #[cfg(any(test, debug_assertions))]
+            {
                 (*n.inner).prev = ptr::null_mut();
                 (*n.inner).next = ptr::null_mut();
-            }
+            }}
             // (*n).tag = 0;
         }
 

--- a/src/bptree/asynch.rs
+++ b/src/bptree/asynch.rs
@@ -271,7 +271,7 @@ mod tests {
         let map = BptreeMap::new();
         // add values
         {
-            let mut w = map.write().await;
+            let mut w: crate::bptree::asynch::BptreeMapWriteTxn<'_, usize, usize> = map.write().await;
             w.extend((0..(L_CAPACITY * 2)).map(|v| (v * 2, v * 2)));
             w.commit();
         }

--- a/src/bptree/mod.rs
+++ b/src/bptree/mod.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_bptree2_map_from_iter_1() {
         let ins: Vec<usize> = (0..(L_CAPACITY << 4)).collect();
 
-        let map = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
+        let map: BptreeMap<usize, usize> = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
 
         {
             let w = map.write();
@@ -195,7 +195,7 @@ mod tests {
         let mut ins: Vec<usize> = (0..(L_CAPACITY << 4)).collect();
         ins.shuffle(&mut rng);
 
-        let map = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
+        let map: BptreeMap<usize, usize> = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
 
         {
             let w = map.write();
@@ -211,7 +211,7 @@ mod tests {
 
     fn bptree_map_basic_concurrency(lower: usize, upper: usize) {
         // Create a map
-        let map = BptreeMap::new();
+        let map: BptreeMap<usize, usize> = BptreeMap::new();
 
         // add values
         {
@@ -276,7 +276,7 @@ mod tests {
         // Need to ensure that txns are dropped in order.
 
         // Add data, enough to cause a split. All data should be *2
-        let map = BptreeMap::new();
+        let map: BptreeMap<usize, usize> = BptreeMap::new();
         // add values
         {
             let mut w = map.write();
@@ -346,7 +346,7 @@ mod tests {
     fn test_bptree2_map_rangeiter_1() {
         let ins: Vec<usize> = (0..100).collect();
 
-        let map = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
+        let map: BptreeMap<usize, usize, parking_lot::RawMutex> = BptreeMap::from_iter(ins.into_iter().map(|v| (v, v)));
 
         {
             let w = map.write();
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_bptree2_map_rangeiter_2() {
-        let map = BptreeMap::from_iter([(3, ()), (4, ()), (0, ())]);
+        let map: BptreeMap<i32, (), parking_lot::RawMutex> = BptreeMap::from_iter([(3, ()), (4, ()), (0, ())]);
 
         let r = map.read();
         assert!(r.range(1..=2).count() == 0);
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_bptree2_map_rangeiter_3() {
-        let map = BptreeMap::from_iter([0, 1, 2, 3, 4, 5, 6, 8].map(|v| (v, ())));
+        let map: BptreeMap<i32, (), parking_lot::RawMutex> = BptreeMap::from_iter([0, 1, 2, 3, 4, 5, 6, 8].map(|v| (v, ())));
 
         let r = map.read();
         assert!(r.range((Bound::Excluded(6), Bound::Included(7))).count() == 0);

--- a/src/cowcell/asynch.rs
+++ b/src/cowcell/asynch.rs
@@ -2,6 +2,7 @@
 //!
 //! See `CowCell` for more details.
 
+// We can use std here as the `asynch` feature requires the `std` feature
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use tokio::sync::{Mutex, MutexGuard};

--- a/src/cowcell/mod.rs
+++ b/src/cowcell/mod.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 /// use concread::cowcell::CowCell;
 ///
 /// let data: i64 = 0;
-/// let cowcell = CowCell::new(data);
+/// let cowcell = CowCell::<i64>::new(data);
 ///
 /// // Begin a read transaction
 /// let read_txn = cowcell.read();

--- a/src/ebrcell/mod.rs
+++ b/src/ebrcell/mod.rs
@@ -191,7 +191,7 @@ where
                 caller: self,
                 _guard: mguard,
             }
-        }).ok()
+        })
     }
 
     /// This is an internal component of the commit cycle. It takes ownership

--- a/src/hashmap/asynch.rs
+++ b/src/hashmap/asynch.rs
@@ -17,8 +17,8 @@ use crate::internals::lincowcell_async::{LinCowCell, LinCowCellReadTxn, LinCowCe
 
 include!("impl.rs");
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashMap<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashMap<K, V, M>
 {
     /// Construct a new concurrent hashmap
     pub fn new() -> Self {
@@ -30,29 +30,29 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Initiate a read transaction for the Hashmap, concurrent to any
     /// other readers or writers.
-    pub fn read<'x>(&'x self) -> HashMapReadTxn<'x, K, V> {
+    pub fn read<'x>(&'x self) -> HashMapReadTxn<'x, K, V, M> {
         let inner = self.inner.read();
         HashMapReadTxn { inner }
     }
 
     /// Initiate a write transaction for the map, exclusive to this
     /// writer, and concurrently to all existing reads.
-    pub async fn write<'x>(&'x self) -> HashMapWriteTxn<'x, K, V> {
+    pub async fn write<'x>(&'x self) -> HashMapWriteTxn<'x, K, V, M> {
         let inner = self.inner.write().await;
         HashMapWriteTxn { inner }
     }
 
     /// Attempt to create a new write, returns None if another writer
     /// already exists.
-    pub fn try_write(&self) -> Option<HashMapWriteTxn<'_, K, V>> {
+    pub fn try_write(&self) -> Option<HashMapWriteTxn<'_, K, V, M>> {
         self.inner
             .try_write()
             .map(|inner| HashMapWriteTxn { inner })
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashMapWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashMapWriteTxn<'_, K, V, M>
 {
     /// Commit the changes from this write transaction. Readers after this point
     /// will be able to perceive these changes.

--- a/src/hashmap/impl.rs
+++ b/src/hashmap/impl.rs
@@ -1,3 +1,5 @@
+use lock_api::RawMutex;
+
 use crate::internals::hashmap::cursor::CursorReadOps;
 use crate::internals::hashmap::cursor::{CursorRead, CursorWrite, SuperBlock};
 use crate::internals::hashmap::iter::*;
@@ -27,32 +29,34 @@ use std::iter::FromIterator;
 ///
 /// Transactions can be rolled-back (aborted) without penalty by dropping
 /// the `HashMapWriteTxn` without calling `commit()`.
-pub struct HashMap<K, V>
+pub struct HashMap<K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: LinCowCell<SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCell<SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
-unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Send for HashMap<K, V>
+unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + Send + 'static>
+    Send for HashMap<K, V, M>
 {
 }
-unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Sync for HashMap<K, V>
+unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + Send + Sync + 'static>
+    Sync for HashMap<K, V, M>
 {
 }
 
 /// An active read transaction over a `HashMap`. The data in this tree
 /// is guaranteed to not change and will remain consistent for the life
 /// of this transaction.
-pub struct HashMapReadTxn<'a, K, V>
+pub struct HashMapReadTxn<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: LinCowCellReadTxn<'a, SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCellReadTxn<'a, SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
 /// An active write transaction for a `HashMap`. The data in this tree
@@ -60,20 +64,22 @@ where
 /// readers. The write may be rolledback/aborted by dropping this guard
 /// without calling `commit()`. Once `commit()` is called, readers will be
 /// able to access and perceive changes in new transactions.
-pub struct HashMapWriteTxn<'a, K, V>
+pub struct HashMapWriteTxn<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: LinCowCellWriteTxn<'a, SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCellWriteTxn<'a, SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
-enum SnapshotType<'a, K, V>
+enum SnapshotType<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    R(&'a CursorRead<K, V>),
+    R(&'a CursorRead<K, V, M>),
     W(&'a CursorWrite<K, V>),
 }
 
@@ -85,29 +91,30 @@ where
 /// This snapshot IS safe within the read thread due to the nature of the
 /// implementation borrowing the inner tree to prevent mutations within the
 /// same thread while the read snapshot is open.
-pub struct HashMapReadSnapshot<'a, K, V>
+pub struct HashMapReadSnapshot<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: SnapshotType<'a, K, V>,
+    inner: SnapshotType<'a, K, V, M>,
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static> Default
-    for HashMap<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static> Default
+    for HashMap<K, V, M>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    FromIterator<(K, V)> for HashMap<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    FromIterator<(K, V)> for HashMap<K, V, M>
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut new_sblock = unsafe { SuperBlock::new() };
-        let prev = new_sblock.create_reader();
-        let mut cursor = new_sblock.create_writer();
+        let prev: CursorRead<K, V, M> = new_sblock.create_reader();
+        let mut cursor = <SuperBlock<K, V> as LinCowCellCapable<CursorRead<K, V, M>, CursorWrite<K, V>>>::create_writer(&new_sblock); //new_sblock.create_writer();
         cursor.extend(iter);
 
         let _ = new_sblock.pre_commit(cursor, &prev);
@@ -118,16 +125,16 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Extend<(K, V)> for HashMapWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    Extend<(K, V)> for HashMapWriteTxn<'_, K, V, M>
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         self.inner.as_mut().extend(iter);
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashMapWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashMapWriteTxn<'_, K, V, M>
 {
     /*
     pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
@@ -225,15 +232,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     /// Create a read-snapshot of the current map. This does NOT guarantee the map may
     /// not be mutated during the read, so you MUST guarantee that no functions of the
     /// write txn are called while this snapshot is active.
-    pub fn to_snapshot(&self) -> HashMapReadSnapshot<K, V> {
+    pub fn to_snapshot(&self) -> HashMapReadSnapshot<K, V, M> {
         HashMapReadSnapshot {
             inner: SnapshotType::W(self.inner.as_ref()),
         }
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashMapReadTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex>
+    HashMapReadTxn<'_, K, V, M>
 {
     pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
@@ -290,15 +297,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Create a read-snapshot of the current tree.
     /// As this is the read variant, it IS safe, and guaranteed the tree will not change.
-    pub fn to_snapshot(&self) -> HashMapReadSnapshot<K, V> {
+    pub fn to_snapshot(&self) -> HashMapReadSnapshot<K, V, M> {
         HashMapReadSnapshot {
             inner: SnapshotType::R(self.inner.as_ref()),
         }
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashMapReadSnapshot<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashMapReadSnapshot<'_, K, V, M>
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.

--- a/src/hashtrie/impl.rs
+++ b/src/hashtrie/impl.rs
@@ -27,7 +27,7 @@ use std::iter::FromIterator;
 ///
 /// Transactions can be rolled-back (aborted) without penalty by dropping
 /// the `HashTrieWriteTxn` without calling `commit()`.
-pub struct HashTrie<K, V, M>
+pub struct HashTrie<K, V, M = crate::utils::DefaultRawMutex>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
@@ -98,7 +98,7 @@ where
     inner: SnapshotType<'a, K, V, M>,
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex> Default
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static> Default
     for HashTrie<K, V, M>
 {
     fn default() -> Self {

--- a/src/hashtrie/impl.rs
+++ b/src/hashtrie/impl.rs
@@ -1,3 +1,5 @@
+use lock_api::RawMutex;
+
 use crate::internals::hashtrie::cursor::CursorReadOps;
 use crate::internals::hashtrie::cursor::{CursorRead, CursorWrite, SuperBlock};
 use crate::internals::hashtrie::iter::*;
@@ -25,32 +27,34 @@ use std::iter::FromIterator;
 ///
 /// Transactions can be rolled-back (aborted) without penalty by dropping
 /// the `HashTrieWriteTxn` without calling `commit()`.
-pub struct HashTrie<K, V>
+pub struct HashTrie<K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
-    inner: LinCowCell<SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCell<SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
-unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Send for HashTrie<K, V>
+unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + Send + 'static>
+    Send for HashTrie<K, V, M>
 {
 }
-unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Sync for HashTrie<K, V>
+unsafe impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + Send + Sync + 'static>
+    Sync for HashTrie<K, V, M>
 {
 }
 
 /// An active read transaction over a `HashTrie`. The data in this tree
 /// is guaranteed to not change and will remain consistent for the life
 /// of this transaction.
-pub struct HashTrieReadTxn<'a, K, V>
+pub struct HashTrieReadTxn<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: LinCowCellReadTxn<'a, SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCellReadTxn<'a, SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
 /// An active write transaction for a `HashTrie`. The data in this tree
@@ -58,20 +62,22 @@ where
 /// readers. The write may be rolledback/aborted by dropping this guard
 /// without calling `commit()`. Once `commit()` is called, readers will be
 /// able to access and perceive changes in new transactions.
-pub struct HashTrieWriteTxn<'a, K, V>
+pub struct HashTrieWriteTxn<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex
 {
-    inner: LinCowCellWriteTxn<'a, SuperBlock<K, V>, CursorRead<K, V>, CursorWrite<K, V>>,
+    inner: LinCowCellWriteTxn<'a, SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>,
 }
 
-enum SnapshotType<'a, K, V>
+enum SnapshotType<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
-    R(&'a CursorRead<K, V>),
+    R(&'a CursorRead<K, V, M>),
     W(&'a CursorWrite<K, V>),
 }
 
@@ -83,29 +89,33 @@ where
 /// This snapshot IS safe within the read thread due to the nature of the
 /// implementation borrowing the inner tree to prevent mutations within the
 /// same thread while the read snapshot is open.
-pub struct HashTrieReadSnapshot<'a, K, V>
+pub struct HashTrieReadSnapshot<'a, K, V, M>
 where
     K: Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
-    inner: SnapshotType<'a, K, V>,
+    inner: SnapshotType<'a, K, V, M>,
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static> Default
-    for HashTrie<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex> Default
+    for HashTrie<K, V, M>
 {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    FromIterator<(K, V)> for HashTrie<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    FromIterator<(K, V)> for HashTrie<K, V, M>
 {
     fn from_iter<I: IntoIterator<Item = (K, V)>>(iter: I) -> Self {
         let mut new_sblock = unsafe { SuperBlock::new() };
-        let prev = new_sblock.create_reader();
-        let mut cursor = new_sblock.create_writer();
+        let prev: CursorRead<K, V, M> = new_sblock.create_reader();
+        
+        // TODO - can we specify the bound some other way that doesn't make this type vomit?
+        use crate::internals::hashtrie::cursor;
+        let mut cursor = <cursor::SuperBlock<K, V> as LinCowCellCapable<cursor::CursorRead<K, V, M>, cursor::CursorWrite<K, V>>>::create_writer(&new_sblock);
         cursor.extend(iter);
 
         let _ = new_sblock.pre_commit(cursor, &prev);
@@ -116,16 +126,16 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    Extend<(K, V)> for HashTrieWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    Extend<(K, V)> for HashTrieWriteTxn<'_, K, V, M>
 {
     fn extend<I: IntoIterator<Item = (K, V)>>(&mut self, iter: I) {
         self.inner.as_mut().extend(iter);
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrieWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrieWriteTxn<'_, K, V, M>
 {
     /*
     pub(crate) fn prehash<Q>(&self, k: &Q) -> u64
@@ -223,15 +233,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     /// Create a read-snapshot of the current map. This does NOT guarantee the map may
     /// not be mutated during the read, so you MUST guarantee that no functions of the
     /// write txn are called while this snapshot is active.
-    pub fn to_snapshot(&self) -> HashTrieReadSnapshot<K, V> {
+    pub fn to_snapshot(&self) -> HashTrieReadSnapshot<K, V, M> {
         HashTrieReadSnapshot {
             inner: SnapshotType::W(self.inner.as_ref()),
         }
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrieReadTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrieReadTxn<'_, K, V, M>
 {
     pub(crate) fn get_prehashed<Q>(&self, k: &Q, k_hash: u64) -> Option<&V>
     where
@@ -288,15 +298,15 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Create a read-snapshot of the current tree.
     /// As this is the read variant, it IS safe, and guaranteed the tree will not change.
-    pub fn to_snapshot(&self) -> HashTrieReadSnapshot<K, V> {
+    pub fn to_snapshot(&self) -> HashTrieReadSnapshot<K, V, M> {
         HashTrieReadSnapshot {
             inner: SnapshotType::R(self.inner.as_ref()),
         }
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrieReadSnapshot<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrieReadSnapshot<'_, K, V, M>
 {
     /// Retrieve a value from the tree. If the value exists, a reference is returned
     /// as `Some(&V)`, otherwise if not present `None` is returned.

--- a/src/hashtrie/mod.rs
+++ b/src/hashtrie/mod.rs
@@ -50,7 +50,7 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     pub fn new() -> Self {
         // I acknowledge I understand what is required to make this safe.
         HashTrie {
-            inner: LinCowCell::new(unsafe { SuperBlock::new() }),
+            inner: LinCowCell::<SuperBlock<K, V>, CursorRead<K, V, M>, CursorWrite<K, V>, M>::new(unsafe { SuperBlock::new() }),
         }
     }
 
@@ -70,7 +70,7 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Attempt to create a new write, returns None if another writer
     /// already exists.
-    pub fn try_write(&self) -> Option<HashTrieWriteTxn<'_, K, V, M>> {
+    pub fn try_write(&self) -> Option<HashTrieWriteTxn<K, V, M>> {
         self.inner
             .try_write()
             .map(|inner| HashTrieWriteTxn { inner })

--- a/src/hashtrie/mod.rs
+++ b/src/hashtrie/mod.rs
@@ -43,8 +43,8 @@ use crate::internals::lincowcell::{LinCowCell, LinCowCellReadTxn, LinCowCellWrit
 
 include!("impl.rs");
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrie<K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrie<K, V, M>
 {
     /// Construct a new concurrent hashtrie
     pub fn new() -> Self {
@@ -56,29 +56,29 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 
     /// Initiate a read transaction for the Hashmap, concurrent to any
     /// other readers or writers.
-    pub fn read(&self) -> HashTrieReadTxn<K, V> {
+    pub fn read(&self) -> HashTrieReadTxn<K, V, M> {
         let inner = self.inner.read();
         HashTrieReadTxn { inner }
     }
 
     /// Initiate a write transaction for the map, exclusive to this
     /// writer, and concurrently to all existing reads.
-    pub fn write(&self) -> HashTrieWriteTxn<K, V> {
+    pub fn write(&self) -> HashTrieWriteTxn<K, V, M> {
         let inner = self.inner.write();
         HashTrieWriteTxn { inner }
     }
 
     /// Attempt to create a new write, returns None if another writer
     /// already exists.
-    pub fn try_write(&self) -> Option<HashTrieWriteTxn<K, V>> {
+    pub fn try_write(&self) -> Option<HashTrieWriteTxn<K, V, M>> {
         self.inner
             .try_write()
             .map(|inner| HashTrieWriteTxn { inner })
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrieWriteTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrieWriteTxn<'_, K, V, M>
 {
     /// View the current transaction ID for this cache. This is a monotonically increasing
     /// value. If two transactions have the same txid, they are the same data generation.
@@ -113,8 +113,8 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
     }
 }
 
-impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static>
-    HashTrieReadTxn<'_, K, V>
+impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Send + 'static, M: RawMutex + 'static>
+    HashTrieReadTxn<'_, K, V, M>
 {
     /// View the current transaction ID for this cache. This is a monotonically increasing
     /// value. If two transactions have the same txid, they are the same data generation.
@@ -133,10 +133,11 @@ impl<K: Hash + Eq + Clone + Debug + Sync + Send + 'static, V: Clone + Sync + Sen
 }
 
 #[cfg(feature = "serde")]
-impl<K, V> Serialize for HashTrieReadTxn<'_, K, V>
+impl<K, V, M> Serialize for HashTrieReadTxn<'_, K, V, M>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Serialize + Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -153,10 +154,11 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<K, V> Serialize for HashTrie<K, V>
+impl<K, V, M> Serialize for HashTrie<K, V, M>
 where
     K: Serialize + Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Serialize + Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -167,10 +169,11 @@ where
 }
 
 #[cfg(feature = "serde")]
-impl<'de, K, V> Deserialize<'de> for HashTrie<K, V>
+impl<'de, K, V, M> Deserialize<'de> for HashTrie<K, V, M>
 where
     K: Deserialize<'de> + Hash + Eq + Clone + Debug + Sync + Send + 'static,
     V: Deserialize<'de> + Clone + Sync + Send + 'static,
+    M: RawMutex + 'static
 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/internals/bptree/iter.rs
+++ b/src/internals/bptree/iter.rs
@@ -1,12 +1,16 @@
 //! Iterators for the map.
 
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::collections::VecDeque;
+
 // Iterators for the bptree
 use super::node::{Branch, Leaf, Meta, Node};
-use std::borrow::Borrow;
-use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::marker::PhantomData;
-use std::ops::{Bound, RangeBounds};
+use core::borrow::Borrow;
+use core::fmt::Debug;
+use core::marker::PhantomData;
+use core::ops::{Bound, RangeBounds};
 
 pub(crate) struct LeafIter<'a, K, V>
 where

--- a/src/internals/bptree/mutiter.rs
+++ b/src/internals/bptree/mutiter.rs
@@ -81,8 +81,7 @@ mod tests {
     use super::super::cursor::SuperBlock;
     use super::super::node::{Leaf, Node, L_CAPACITY};
     use super::RangeMutIter;
-    use std::ops::Bound;
-    use std::ops::Bound::*;
+    use std::ops::Bound::{self, *};
 
     use crate::internals::lincowcell::LinCowCellCapable;
 

--- a/src/internals/bptree/mutiter.rs
+++ b/src/internals/bptree/mutiter.rs
@@ -83,6 +83,7 @@ mod tests {
     use super::RangeMutIter;
     use std::ops::Bound::{self, *};
 
+    use crate::internals::bptree::cursor::{CursorRead, CursorWrite};
     use crate::internals::lincowcell::LinCowCellCapable;
 
     fn create_leaf_node_full(vbase: usize) -> *mut Node<usize, usize> {
@@ -103,7 +104,7 @@ mod tests {
         let node = create_leaf_node_full(10);
 
         let sb = SuperBlock::new_test(1, node as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         let bounds: (Bound<usize>, Bound<usize>) = (Unbounded, Unbounded);
         let range_mut_iter = RangeMutIter::new(&mut wcurs, bounds);

--- a/src/internals/hashmap/cursor.rs
+++ b/src/internals/hashmap/cursor.rs
@@ -19,8 +19,8 @@ use vec::Vec;
 #[cfg(any(feature = "ahash", not(feature = "std")))]
 use ahash::RandomState;
 
-#[cfg(feature = "foldhash")]
-use foldhash::fast::RandomState;
+//#[cfg(feature = "foldhash")]
+//use foldhash::fast::RandomState;
 
 #[cfg(all(not(feature = "ahash"), not(feature = "foldhash")))]
 use std::collections::hash_map::RandomState;
@@ -145,7 +145,7 @@ impl<K: Hash + Eq + Clone + Debug, V: Clone> SuperBlock<K, V> {
 }
 
 #[derive(Debug)]
-pub(crate) struct CursorRead<K, V, M>
+pub(crate) struct CursorRead<K, V, M = crate::utils::DefaultRawMutex>
 where
     K: Hash + Eq + Clone + Debug,
     V: Clone,
@@ -1112,6 +1112,7 @@ mod tests {
     use super::super::states::*;
     use super::SuperBlock;
     use super::{CursorRead, CursorReadOps};
+    use crate::internals::hashmap::cursor::CursorWrite;
     use crate::internals::lincowcell::LinCowCellCapable;
     use rand::seq::SliceRandom;
     use std::mem;
@@ -1161,7 +1162,7 @@ mod tests {
         // First create the node + cursor
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         let prev_txid = wcurs.root_txid();
 
         // Now insert - the txid should be different.
@@ -1197,7 +1198,7 @@ mod tests {
 
         let node = create_leaf_node_full(10);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         let prev_txid = wcurs.root_txid();
 
         let r = wcurs.insert(1, 1, 1);
@@ -1219,7 +1220,7 @@ mod tests {
         // to trigger a clone of leaf AND THEN to cause the split.
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in 1..(H_CAPACITY + 1) {
             // println!("ITER v {}", v);
@@ -1247,7 +1248,7 @@ mod tests {
         let rnode = create_leaf_node_full(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         assert!(wcurs.verify());
         // println!("{:?}", wcurs);
@@ -1277,7 +1278,7 @@ mod tests {
         let rnode = create_leaf_node_full(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         let r = wcurs.insert(29, 29, 29);
@@ -1305,7 +1306,7 @@ mod tests {
         let rnode = create_leaf_node(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         // Now insert to trigger the needed actions.
@@ -1339,7 +1340,7 @@ mod tests {
         let rnode = create_leaf_node(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         // Now insert to trigger the needed actions.
@@ -1370,7 +1371,7 @@ mod tests {
         let rnode = create_leaf_node(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         let r = wcurs.insert(11, 11, 11);
@@ -1405,7 +1406,7 @@ mod tests {
         let rnode = create_leaf_node_full(20);
         let root = Node::new_branch(0, lnode, rnode);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         let r = wcurs.insert(19, 19, 19);
@@ -1430,7 +1431,7 @@ mod tests {
         // so we do this to a reasonable number.
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in 1..(H_CAPACITY << 4) {
             // println!("ITER v {}", v);
@@ -1451,7 +1452,7 @@ mod tests {
         // Insert descending
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in (1..(H_CAPACITY << 4)).rev() {
             // println!("ITER v {}", v);
@@ -1476,7 +1477,7 @@ mod tests {
 
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in ins.into_iter() {
             let r = wcurs.insert(v as u64, v, v);
@@ -1497,10 +1498,10 @@ mod tests {
         // Insert ascending - we want to ensure the tree is a few levels deep
         // so we do this to a reasonable number.
         let mut sb = unsafe { SuperBlock::new() };
-        let mut rdr = sb.create_reader();
+        let mut rdr: CursorRead<usize, usize> = sb.create_reader();
 
         for v in 1..(H_CAPACITY << 4) {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             // println!("ITER v {}", v);
             let r = wcurs.insert(v as u64, v, v);
             assert!(r.is_none());
@@ -1518,10 +1519,10 @@ mod tests {
     fn test_hashmap2_cursor_insert_stress_5() {
         // Insert descending
         let mut sb = unsafe { SuperBlock::new() };
-        let mut rdr = sb.create_reader();
+        let mut rdr: CursorRead<usize, usize> = sb.create_reader();
 
         for v in (1..(H_CAPACITY << 4)).rev() {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             // println!("ITER v {}", v);
             let r = wcurs.insert(v as u64, v, v);
             assert!(r.is_none());
@@ -1543,10 +1544,10 @@ mod tests {
         ins.shuffle(&mut rng);
 
         let mut sb = unsafe { SuperBlock::new() };
-        let mut rdr = sb.create_reader();
+        let mut rdr: CursorRead<usize, usize> = sb.create_reader();
 
         for v in ins.into_iter() {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             let r = wcurs.insert(v as u64, v, v);
             assert!(r.is_none());
             assert!(wcurs.verify());
@@ -1563,7 +1564,7 @@ mod tests {
     fn test_hashmap2_cursor_search_1() {
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in 1..(H_CAPACITY << 4) {
             let r = wcurs.insert(v as u64, v, v);
@@ -1587,7 +1588,7 @@ mod tests {
         // Check the length is consistent on operations.
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in 1..(H_CAPACITY << 4) {
             let r = wcurs.insert(v as u64, v, v);
@@ -1610,7 +1611,7 @@ mod tests {
         //
         let lnode = create_leaf_node_full(0);
         let sb = SuperBlock::new_test(1, lnode);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         // println!("{:?}", wcurs);
 
         for v in 0..H_CAPACITY {
@@ -1633,7 +1634,7 @@ mod tests {
     fn test_hashmap2_cursor_remove_01_p1() {
         let node = create_leaf_node(0);
         let sb = SuperBlock::new_test(1, node);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         let _ = wcurs.remove(0, &0);
         // println!("{:?}", wcurs);
@@ -1659,7 +1660,7 @@ mod tests {
         // Prevent the tree shrinking.
         unsafe { (*root).add_node(rnode) };
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         println!("{:?}", wcurs);
         assert!(wcurs.verify());
         wcurs.remove(20, &20);
@@ -1685,7 +1686,7 @@ mod tests {
         // Prevent the tree shrinking.
         unsafe { (*root).add_node(znode) };
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(10, &10);
@@ -1711,7 +1712,7 @@ mod tests {
         // Prevent the tree shrinking.
         unsafe { (*root).add_node(rnode) };
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         // Setup sibling leaf to already be cloned.
@@ -1741,7 +1742,7 @@ mod tests {
         // Prevent the tree shrinking.
         unsafe { (*root).add_node(rnode) };
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         // Setup leaf to already be cloned.
@@ -1771,7 +1772,7 @@ mod tests {
         // Prevent the tree shrinking.
         unsafe { (*root).add_node(znode) };
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         // Setup leaf to already be cloned.
@@ -1811,7 +1812,7 @@ mod tests {
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
 
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         assert!(wcurs.verify());
 
@@ -1849,7 +1850,7 @@ mod tests {
         let root: *mut Branch<usize, usize> =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(10, &10);
@@ -1886,7 +1887,7 @@ mod tests {
         let root: *mut Branch<usize, usize> =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(80, &80);
@@ -1923,7 +1924,7 @@ mod tests {
         let root: *mut Branch<usize, usize> =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(10, &10);
@@ -1960,7 +1961,7 @@ mod tests {
         let root: *mut Branch<usize, usize> =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         assert!(wcurs.verify());
 
@@ -2001,7 +2002,7 @@ mod tests {
         let root: *mut Branch<usize, usize> =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _);
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.path_clone(20);
@@ -2042,7 +2043,7 @@ mod tests {
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _) as *mut Node<usize, usize>;
         // let count = HBV_CAPACITY + 2;
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.path_clone(0);
@@ -2083,7 +2084,7 @@ mod tests {
         let root =
             Node::new_branch(0, lbranch as *mut _, rbranch as *mut _) as *mut Node<usize, usize>;
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         for i in 0..HBV_CAPACITY {
@@ -2107,7 +2108,7 @@ mod tests {
         let rnode = create_leaf_node(20);
         let root = Node::new_branch(0, lnode, rnode) as *mut Node<usize, usize>;
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(20, &20);
@@ -2125,7 +2126,7 @@ mod tests {
         let rnode = create_leaf_node_full(20) as *mut Node<usize, usize>;
         let root = Node::new_branch(0, lnode, rnode) as *mut Node<usize, usize>;
         let sb = SuperBlock::new_test(1, root as *mut Node<usize, usize>);
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
         assert!(wcurs.verify());
 
         wcurs.remove(10, &10);
@@ -2143,7 +2144,7 @@ mod tests {
 
         let mut sb = unsafe { SuperBlock::new() };
         let rdr = sb.create_reader();
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in ins.into_iter() {
             let r = wcurs.insert(v as u64, v, v);
@@ -2160,7 +2161,7 @@ mod tests {
         // Insert ascending - we want to ensure the tree is a few levels deep
         // so we do this to a reasonable number.
         let (mut sb, rdr) = tree_create_rand();
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in 1..(H_CAPACITY << 4) {
             // println!("-- ITER v {}", v);
@@ -2181,7 +2182,7 @@ mod tests {
     fn test_hashmap2_cursor_remove_stress_2() {
         // Insert descending
         let (mut sb, rdr) = tree_create_rand();
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in (1..(H_CAPACITY << 4)).rev() {
             // println!("ITER v {}", v);
@@ -2207,7 +2208,7 @@ mod tests {
         ins.shuffle(&mut rng);
 
         let (mut sb, rdr) = tree_create_rand();
-        let mut wcurs = sb.create_writer();
+        let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
 
         for v in ins.into_iter() {
             let r = wcurs.remove(v as u64, &v);
@@ -2232,7 +2233,7 @@ mod tests {
         let (mut sb, mut rdr) = tree_create_rand();
 
         for v in 1..(H_CAPACITY << 4) {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             // println!("ITER v {}", v);
             let r = wcurs.remove(v as u64, &v);
             assert!(r == Some(v));
@@ -2252,7 +2253,7 @@ mod tests {
         let (mut sb, mut rdr) = tree_create_rand();
 
         for v in (1..(H_CAPACITY << 4)).rev() {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             // println!("ITER v {}", v);
             let r = wcurs.remove(v as u64, &v);
             assert!(r == Some(v));
@@ -2277,7 +2278,7 @@ mod tests {
         let (mut sb, mut rdr) = tree_create_rand();
 
         for v in ins.into_iter() {
-            let mut wcurs = sb.create_writer();
+            let mut wcurs = <SuperBlock<usize, usize> as LinCowCellCapable<CursorRead<usize, usize>, CursorWrite<usize, usize>>>::create_writer(&sb);
             let r = wcurs.remove(v as u64, &v);
             assert!(r == Some(v));
             assert!(wcurs.verify());

--- a/src/internals/hashmap/iter.rs
+++ b/src/internals/hashmap/iter.rs
@@ -1,11 +1,15 @@
 //! Iterators for the map.
 
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
+#[cfg(not(feature = "std"))]
+use alloc::collections::VecDeque;
+
 // Iterators for the bptree
 use super::node::{Branch, Leaf, Meta, Node};
-use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::marker::PhantomData;
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::marker::PhantomData;
 
 pub(crate) struct LeafIter<'a, K, V>
 where

--- a/src/internals/hashmap/macros.rs
+++ b/src/internals/hashmap/macros.rs
@@ -31,7 +31,7 @@ macro_rules! branch_ref {
     ($x:expr, $k:ty, $v:ty) => {{
         #[allow(unused_unsafe)]
         unsafe {
-            debug_assert!(unsafe { (*$x).ctrl.a.0.is_branch() });
+            debug_assert!(unsafe { $x.as_ref().unwrap().ctrl.a.0.is_branch() });
             &mut *($x as *mut Branch<$k, $v>)
         }
     }};
@@ -41,7 +41,7 @@ macro_rules! leaf_ref {
     ($x:expr, $k:ty, $v:ty) => {{
         #[allow(unused_unsafe)]
         unsafe {
-            debug_assert!(unsafe { (*$x).ctrl.a.0.is_leaf() });
+            debug_assert!(unsafe { $x.as_ref().unwrap().ctrl.a.0.is_leaf() });
             &mut *($x as *mut Leaf<$k, $v>)
         }
     }};

--- a/src/internals/hashmap/simd.rs
+++ b/src/internals/hashmap/simd.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "simd_support")]
-use core_simd::u64x8;
+use std::simd::u64x8;
 use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/src/internals/hashtrie/iter.rs
+++ b/src/internals/hashtrie/iter.rs
@@ -1,10 +1,14 @@
 //! Iterators for the hashtrie
 
-use super::cursor::{Ptr, HT_CAPACITY, MAX_HEIGHT};
+#[cfg(feature = "std")]
 use std::collections::VecDeque;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use alloc::collections::VecDeque;
+
+use super::cursor::{Ptr, HT_CAPACITY, MAX_HEIGHT};
+use core::fmt::Debug;
+use core::hash::Hash;
+use core::marker::PhantomData;
 
 /// Iterator over references to Key Value pairs stored in the map.
 pub struct Iter<'a, K, V>

--- a/src/internals/lincowcell_async/mod.rs
+++ b/src/internals/lincowcell_async/mod.rs
@@ -65,19 +65,21 @@ use crate::internals::lincowcell::LinCowCellCapable;
 
 #[derive(Debug)]
 /// A concurrently readable cell with linearised drop behaviour.
-pub struct LinCowCell<T, R, U> {
+pub struct LinCowCell<T, R, U, M = ()> {
     updater: PhantomData<U>,
     write: Mutex<T>,
     active: SyncMutex<Arc<LinCowCellInner<R>>>,
+    _phantom: PhantomData<M>
 }
 
 #[derive(Debug)]
 /// A write txn over a linear cell.
-pub struct LinCowCellWriteTxn<'a, T, R, U> {
+pub struct LinCowCellWriteTxn<'a, T, R, U, M> {
     // This way we know who to contact for updating our data ....
-    caller: &'a LinCowCell<T, R, U>,
+    caller: &'a LinCowCell<T, R, U, M>,
     guard: MutexGuard<'a, T>,
     work: U,
+    _phantom: PhantomData<M>
 }
 
 #[derive(Debug)]
@@ -89,9 +91,9 @@ struct LinCowCellInner<R> {
 
 #[derive(Debug)]
 /// A read txn over a linear cell.
-pub struct LinCowCellReadTxn<'a, T, R, U> {
+pub struct LinCowCellReadTxn<'a, T, R, U, M> {
     // We must outlive the root
-    _caller: &'a LinCowCell<T, R, U>,
+    _caller: &'a LinCowCell<T, R, U, M>,
     // We pin the current version.
     work: Arc<LinCowCellInner<R>>,
 }
@@ -127,7 +129,7 @@ impl<R> Drop for LinCowCellInner<R> {
     }
 }
 
-impl<T, R, U> LinCowCell<T, R, U>
+impl<T, R, U, M> LinCowCell<T, R, U, M>
 where
     T: LinCowCellCapable<R, U>,
 {
@@ -138,11 +140,12 @@ where
             updater: PhantomData,
             write: Mutex::new(data),
             active: SyncMutex::new(Arc::new(LinCowCellInner::new(r))),
+            _phantom: PhantomData
         }
     }
 
     /// Begin a read txn
-    pub fn read(&self) -> LinCowCellReadTxn<'_, T, R, U> {
+    pub fn read(&self) -> LinCowCellReadTxn<'_, T, R, U, M> {
         let rwguard = self.active.lock().unwrap();
         LinCowCellReadTxn {
             _caller: self,
@@ -152,7 +155,7 @@ where
     }
 
     /// Begin a write txn
-    pub async fn write<'x>(&'x self) -> LinCowCellWriteTxn<'x, T, R, U> {
+    pub async fn write<'x>(&'x self) -> LinCowCellWriteTxn<'x, T, R, U, M> {
         /* Take the exclusive write lock first */
         let write_guard = self.write.lock().await;
         /* Now take a ro-txn to get the data copied */
@@ -164,11 +167,12 @@ where
             caller: self,
             guard: write_guard,
             work,
+            _phantom: PhantomData
         }
     }
 
     /// Attempt a write txn
-    pub fn try_write(&self) -> Option<LinCowCellWriteTxn<'_, T, R, U>> {
+    pub fn try_write(&self) -> Option<LinCowCellWriteTxn<'_, T, R, U, M>> {
         self.write
             .try_lock()
             .map(|write_guard| {
@@ -179,18 +183,20 @@ where
                     caller: self,
                     guard: write_guard,
                     work,
+                    _phantom: PhantomData
                 }
             })
             .ok()
     }
 
-    fn commit(&self, write: LinCowCellWriteTxn<'_, T, R, U>) {
+    fn commit(&self, write: LinCowCellWriteTxn<'_, T, R, U, M>) {
         // Destructure our writer.
         let LinCowCellWriteTxn {
             // This is self.
             caller: _caller,
             mut guard,
             work,
+            _phantom: PhantomData
         } = write;
 
         // Get the previous generation.
@@ -212,7 +218,7 @@ where
     }
 }
 
-impl<T, R, U> Deref for LinCowCellReadTxn<'_, T, R, U> {
+impl<T, R, U, M> Deref for LinCowCellReadTxn<'_, T, R, U, M> {
     type Target = R;
 
     #[inline]
@@ -221,14 +227,14 @@ impl<T, R, U> Deref for LinCowCellReadTxn<'_, T, R, U> {
     }
 }
 
-impl<T, R, U> AsRef<R> for LinCowCellReadTxn<'_, T, R, U> {
+impl<T, R, U, M> AsRef<R> for LinCowCellReadTxn<'_, T, R, U, M> {
     #[inline]
     fn as_ref(&self) -> &R {
         &self.work.data
     }
 }
 
-impl<T, R, U> LinCowCellWriteTxn<'_, T, R, U>
+impl<T, R, U, M> LinCowCellWriteTxn<'_, T, R, U, M>
 where
     T: LinCowCellCapable<R, U>,
 {
@@ -245,7 +251,7 @@ where
     }
 }
 
-impl<T, R, U> Deref for LinCowCellWriteTxn<'_, T, R, U> {
+impl<T, R, U, M> Deref for LinCowCellWriteTxn<'_, T, R, U, M> {
     type Target = U;
 
     #[inline]
@@ -254,21 +260,21 @@ impl<T, R, U> Deref for LinCowCellWriteTxn<'_, T, R, U> {
     }
 }
 
-impl<T, R, U> DerefMut for LinCowCellWriteTxn<'_, T, R, U> {
+impl<T, R, U, M> DerefMut for LinCowCellWriteTxn<'_, T, R, U, M> {
     #[inline]
     fn deref_mut(&mut self) -> &mut U {
         &mut self.work
     }
 }
 
-impl<T, R, U> AsRef<U> for LinCowCellWriteTxn<'_, T, R, U> {
+impl<T, R, U, M> AsRef<U> for LinCowCellWriteTxn<'_, T, R, U, M> {
     #[inline]
     fn as_ref(&self) -> &U {
         &self.work
     }
 }
 
-impl<T, R, U> AsMut<U> for LinCowCellWriteTxn<'_, T, R, U> {
+impl<T, R, U, M> AsMut<U> for LinCowCellWriteTxn<'_, T, R, U, M> {
     #[inline]
     fn as_mut(&mut self) -> &mut U {
         &mut self.work
@@ -321,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_create() {
         let data = TestData { x: 0 };
-        let cc = LinCowCell::new(data);
+        let cc: LinCowCell<TestData, TestDataReadTxn, TestDataWriteTxn, ()> = LinCowCell::new(data);
 
         let cc_rotxn_a = cc.read();
         println!("cc_rotxn_a -> {:?}", cc_rotxn_a);
@@ -405,7 +411,7 @@ mod tests {
         let start = Instant::now();
         // Create the new cowcell.
         let data = TestData { x: 0 };
-        let cc = Arc::new(LinCowCell::new(data));
+        let cc: Arc<LinCowCell<TestData, TestDataReadTxn, TestDataWriteTxn>> = Arc::new(LinCowCell::new(data));
 
         let _ = tokio::join!(
             tokio::task::spawn_blocking({
@@ -508,7 +514,7 @@ mod tests {
     async fn test_gc_operation() {
         GC_COUNT.store(0, Ordering::Release);
         let data = TestGcWrapper { data: 0 };
-        let cc = Arc::new(LinCowCell::new(data));
+        let cc: Arc<LinCowCell<TestGcWrapper<i64>, TestGcWrapperReadTxn<i64>, TestGcWrapperWriteTxn<i64>>> = Arc::new(LinCowCell::new(data));
 
         let _ = tokio::join!(
             tokio::task::spawn(test_gc_operation_thread(cc.clone())),
@@ -524,7 +530,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn test_long_chain_drop_no_stack_overflow() {
         let data = TestData { x: 0 };
-        let cc = LinCowCell::new(data);
+        let cc: LinCowCell<TestData, TestDataReadTxn, TestDataWriteTxn> = LinCowCell::new(data);
 
         // Simulate a read txn that is not dropped.
         let initial_read = cc.read();
@@ -612,7 +618,7 @@ mod tests_linear {
         GC_COUNT.store(0, Ordering::Release);
         assert!(GC_COUNT.load(Ordering::Acquire) == 0);
         let data = TestGcWrapper { data: 0 };
-        let cc = LinCowCell::new(data);
+        let cc: LinCowCell<TestGcWrapper<i32>, TestGcWrapperReadTxn<i32>, TestGcWrapperWriteTxn<i32>> = LinCowCell::new(data);
 
         // Open a read A.
         let cc_rotxn_a = cc.read();

--- a/src/lc_tests.rs
+++ b/src/lc_tests.rs
@@ -7,8 +7,8 @@ struct TestStruct {
 }
 
 struct TestStructRead {
-    bptree_map_a: CursorRead<u32, u32>,
-    bptree_map_b: CursorRead<u32, u32>,
+    bptree_map_a: CursorRead<u32, u32, parking_lot::RawMutex>,
+    bptree_map_b: CursorRead<u32, u32, parking_lot::RawMutex>,
 }
 
 struct TestStructWrite {
@@ -28,8 +28,8 @@ impl LinCowCellCapable<TestStructRead, TestStructWrite> for TestStruct {
     fn create_writer(&self) -> TestStructWrite {
         // This sets up the first writer.
         TestStructWrite {
-            bptree_map_a: self.bptree_map_a.create_writer(),
-            bptree_map_b: self.bptree_map_b.create_writer(),
+            bptree_map_a: <SuperBlock<u32, u32> as LinCowCellCapable<CursorRead<u32, u32, parking_lot::RawMutex>, CursorWrite<u32, u32>>>::create_writer(&self.bptree_map_a),
+            bptree_map_b: <SuperBlock<u32, u32> as LinCowCellCapable<CursorRead<u32, u32, parking_lot::RawMutex>, CursorWrite<u32, u32>>>::create_writer(&self.bptree_map_b),
         }
     }
 
@@ -56,7 +56,7 @@ impl LinCowCellCapable<TestStructRead, TestStructWrite> for TestStruct {
 
 #[test]
 fn test_lc_basic() {
-    let lcc = LinCowCell::new(TestStruct {
+    let lcc: LinCowCell<TestStruct, TestStructRead, TestStructWrite, parking_lot::RawMutex> = LinCowCell::new(TestStruct {
         bptree_map_a: unsafe { SuperBlock::new() },
         bptree_map_b: unsafe { SuperBlock::new() },
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,11 +34,24 @@
 //! By default all of these features are enabled. If you are planning to use this crate in a wasm
 //! context we recommend you use only `maps` as a feature.
 
+
+//#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
+
 #![deny(warnings)]
 #![warn(unused_extern_crates)]
 #![warn(missing_docs)]
 #![allow(clippy::needless_lifetimes)]
 #![cfg_attr(feature = "simd_support", feature(portable_simd))]
+
+// TODO - can I remove this? Need a backup to tell if we can use AtomicUsize
+//#![feature(cfg_target_has_atomic)]
+
+#[cfg(not(any(test, feature = "std")))]
+extern crate alloc;
+
+#[cfg(any(test, feature = "std"))]
+extern crate std;
 
 #[cfg(all(test, feature = "dhat-heap"))]
 #[global_allocator]
@@ -64,8 +77,11 @@ pub mod threadcache;
 // This is where the scary rust lives.
 #[cfg(feature = "maps")]
 pub mod internals;
+
 // This is where the good rust lives.
-#[cfg(feature = "maps")]
+// We're allowing unuzed here since we may or may not use all items based on enabled features
+// All potentially incompatible features must be feature gated internally.
+#[allow(unused)]
 mod utils;
 
 #[cfg(feature = "maps")]

--- a/src/unsound3.rs
+++ b/src/unsound3.rs
@@ -13,7 +13,7 @@ enum RefOrInt<'a> {
     Int(u64),
 }
 
-#[cfg(feature = "unsoundness")]
+#[cfg(all(feature = "unsoundness", feature = "std"))]
 fn main() {
     use concread::arcache::ARCache;
     use std::cell::Cell;

--- a/tests/bptree_map.rs
+++ b/tests/bptree_map.rs
@@ -8,7 +8,7 @@ proptest::proptest! {
     fn bptree_range_iter_consistent(values: BTreeSet<u8>, left in 0..u8::MAX - 1, len in 1..u8::MAX, bounds: (Bound<()>, Bound<()>)) {
         let range = (bounds.0.map(|()| left), bounds.1.map(|()| left.saturating_add(len)));
         let btree_map = BTreeMap::from_iter(values.iter().cloned().map(|v| (v, ())));
-        let bptree_map = BptreeMap::from_iter(values.iter().cloned().map(|v| (v, ())));
+        let bptree_map: BptreeMap<u8, ()> = BptreeMap::from_iter(values.iter().cloned().map(|v| (v, ())));
         let bptree_map_read_tx = bptree_map.read();
 
         let btree_iter = btree_map.range(range);
@@ -22,7 +22,7 @@ proptest::proptest! {
     #[test]
     fn bptree_get_consistent(values: BTreeSet<u8>, key: u8) {
         let btree_map = BTreeMap::from_iter(values.iter().cloned().map(|v| (v, v)));
-        let bptree_map = BptreeMap::from_iter(values.iter().cloned().map(|v| (v, v)));
+        let bptree_map: BptreeMap<u8, u8> = BptreeMap::from_iter(values.iter().cloned().map(|v| (v, v)));
         let bptree_map_read_tx = bptree_map.read();
 
         let btree_value = btree_map.get(&key);
@@ -34,7 +34,7 @@ proptest::proptest! {
     #[test]
     fn bptree_remove_consistent(values in proptest::collection::btree_set(proptest::arbitrary::any::<u8>(), 1..256), indices: Vec<proptest::sample::Index> ) {
         let mut btree_map = BTreeMap::from_iter(values.iter().cloned().map(|v| (v.to_string(), v.to_string())));
-        let bptree_map = BptreeMap::from_iter(values.iter().cloned().map(|v| (v.to_string(), v.to_string())));
+        let bptree_map: BptreeMap<String, String> = BptreeMap::from_iter(values.iter().cloned().map(|v| (v.to_string(), v.to_string())));
         let mut bptree_map_write_tx = bptree_map.write();
 
         for index in indices {
@@ -66,7 +66,7 @@ fn bptree_remove_1() {
 
     let to_remove = [9u8, 27, 40, 4].map(|v| v.to_string());
 
-    let bptree_map = BptreeMap::from_iter(
+    let bptree_map: BptreeMap<String, String> = BptreeMap::from_iter(
         values
             .iter()
             .cloned()


### PR DESCRIPTION
This is a start for supporting concread in `no_std` environments. While I am not working on it right now, this was motivated by my desire for a kv-store in a full featured, but non-std environment where the read-heavy hot path should basically never be slowed by writes locking the kv-store.

Most of this was just copy-paste drudgery adding trait bounds on `lock_api`'s `RawMutex` or `RawRwLock` traits, but there may also be some gremlins about if you use the wrong combination of features (I took a lot of time to figure out which dependencies were rebuilding core/alloc in which combinations).

Unfortunately, there were also some dependencies that would build core+alloc with an `alloc` feature enabled even if `std` was also enabled, so consumers of the crate will have to enable the `no_std` feature if they want things to work properly.